### PR TITLE
Add requirement schema validation and surface status warnings

### DIFF
--- a/hooks/lib/config.py
+++ b/hooks/lib/config.py
@@ -97,7 +97,17 @@ class RequirementsConfig:
             project_dir: Project root directory
         """
         self.project_dir = project_dir
+        self.validation_errors: list[str] = []
         self._config = self._load_cascade()
+
+    REQUIREMENT_SCHEMA = {
+        'enabled': {'type': bool},
+        'scope': {'type': str, 'allowed': {'session', 'branch', 'permanent'}},
+        'trigger_tools': {'type': list, 'element_type': str},
+        'checklist': {'type': list, 'element_type': str},
+        'message': {'type': str},
+        'type': {'type': str, 'allowed': {'blocking', 'dynamic'}},
+    }
 
     def _load_cascade(self) -> dict:
         """
@@ -147,6 +157,7 @@ class RequirementsConfig:
                 self._validate_requirement_config(req_name, requirements[req_name])
             except ValueError as e:
                 print(f"⚠️ Config validation error: {e}", file=sys.stderr)
+                self.validation_errors.append(str(e))
                 invalid_requirements.append(req_name)
 
         # Remove invalid requirements (fail-safe approach)
@@ -155,6 +166,44 @@ class RequirementsConfig:
             print(f"⚠️ Disabled invalid requirement: {req_name}", file=sys.stderr)
 
         return config
+
+    def get_validation_errors(self) -> list[str]:
+        """Return any validation errors encountered while loading config."""
+        return list(self.validation_errors)
+
+    def _validate_requirement_schema(self, req_name: str, req_config: dict) -> None:
+        """Validate common requirement fields against schema."""
+        for field, rules in self.REQUIREMENT_SCHEMA.items():
+            if field not in req_config:
+                continue
+
+            value = req_config[field]
+            expected_type = rules['type']
+
+            if expected_type is list:
+                if not isinstance(value, list):
+                    raise ValueError(
+                        f"Requirement '{req_name}' field '{field}' must be a list of strings"
+                    )
+
+                element_type = rules.get('element_type')
+                if element_type:
+                    invalid_items = [item for item in value if not isinstance(item, element_type)]
+                    if invalid_items:
+                        raise ValueError(
+                            f"Requirement '{req_name}' field '{field}' must contain only strings"
+                        )
+            else:
+                if not isinstance(value, expected_type):
+                    raise ValueError(
+                        f"Requirement '{req_name}' field '{field}' must be {expected_type.__name__}"
+                    )
+
+            if 'allowed' in rules and value not in rules['allowed']:
+                allowed_values = ', '.join(sorted(rules['allowed']))
+                raise ValueError(
+                    f"Requirement '{req_name}' field '{field}' must be one of: {allowed_values}"
+                )
 
     def _validate_requirement_config(self, req_name: str, req_config: dict) -> None:
         """
@@ -168,6 +217,9 @@ class RequirementsConfig:
             ValueError: If configuration is invalid
         """
         req_type = req_config.get('type', 'blocking')
+
+        # Validate common fields present on all requirements
+        self._validate_requirement_schema(req_name, req_config)
 
         if req_type == 'dynamic':
             # Validate dynamic requirement fields

--- a/hooks/requirements-cli.py
+++ b/hooks/requirements-cli.py
@@ -96,6 +96,14 @@ def cmd_status(args) -> int:
 
     config = RequirementsConfig(project_dir)
 
+    validation_errors = config.get_validation_errors()
+    if validation_errors:
+        print("⚠️  Configuration validation failed:")
+        for error in validation_errors:
+            print(f"   - {error}")
+        print("   Fix .claude/requirements.yaml and rerun `req status`.")
+        print()
+
     if not config.is_enabled():
         print("⚠️  Requirements framework disabled for this project")
         return 0

--- a/hooks/test_requirements.py
+++ b/hooks/test_requirements.py
@@ -357,6 +357,25 @@ def test_config_module(runner: TestRunner):
         nonexistent = config2.get_checklist("nonexistent")
         runner.test("get_checklist nonexistent returns []", nonexistent == [], f"Got: {nonexistent}")
 
+        # Test schema validation errors
+        invalid_config = {
+            "version": "1.0",
+            "enabled": True,
+            "requirements": {
+                "bad_enabled": {"enabled": "yes"},
+                "bad_scope": {"enabled": True, "scope": "always"},
+                "bad_checklist": {"enabled": True, "checklist": ["ok", 123]},
+            },
+        }
+
+        with open(f"{tmpdir}/.claude/requirements.yaml", 'w') as f:
+            json.dump(invalid_config, f)
+
+        config3 = RequirementsConfig(tmpdir)
+        errors = config3.get_validation_errors()
+        runner.test("Validation errors captured", len(errors) == 3, f"Got: {errors}")
+        runner.test("Invalid requirements removed", config3.get_all_requirements() == [])
+
 
 def test_requirements_manager(runner: TestRunner):
     """Test requirements manager."""
@@ -464,6 +483,35 @@ def test_cli_commands(runner: TestRunner):
             cwd=tmpdir, capture_output=True, text=True
         )
         runner.test("List runs", result.returncode == 0, result.stderr)
+
+    # Validation errors are surfaced in status output
+    with tempfile.TemporaryDirectory() as tmpdir_invalid:
+        subprocess.run(["git", "init"], cwd=tmpdir_invalid, capture_output=True)
+        subprocess.run(["git", "checkout", "-b", "validation"], cwd=tmpdir_invalid, capture_output=True)
+
+        os.makedirs(f"{tmpdir_invalid}/.claude")
+        invalid_config = {
+            "version": "1.0",
+            "enabled": True,
+            "requirements": {
+                "bad_enabled": {"enabled": "yes"}
+            },
+        }
+
+        with open(f"{tmpdir_invalid}/.claude/requirements.yaml", 'w') as f:
+            json.dump(invalid_config, f)
+
+        result = subprocess.run(
+            ["python3", str(cli_path), "status"],
+            cwd=tmpdir_invalid, capture_output=True, text=True
+        )
+
+        runner.test("Status reports validation errors", "Configuration validation failed" in result.stdout, result.stdout)
+        runner.test(
+            "Status includes remediation hint",
+            "Fix .claude/requirements.yaml" in result.stdout,
+            result.stdout,
+        )
 
 
 def test_cli_sessions_command(runner: TestRunner):


### PR DESCRIPTION
## Summary
- validate requirement blocks against a shared schema and capture errors when loading config
- show configuration validation issues and remediation hint in `req status`
- cover valid and invalid configuration paths with new unit tests

## Testing
- python3 hooks/test_requirements.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3de387848326ba28aa54d867f258)