### PR TITLE
test: add permission error fail-open validation tests

### DIFF
--- a/hooks/test_requirements.py
+++ b/hooks/test_requirements.py
@@ -4220,12 +4220,19 @@ def test_permission_errors_fail_open(runner: TestRunner):
     Tests OSError/IOError handling in registry_client, state_storage, and message_dedup_cache.
 
     Skipped on Windows - POSIX permissions don't apply.
+    Skipped when running as root - root can override POSIX DAC restrictions.
     """
     import platform
+    import os
 
     # Skip on Windows - POSIX permissions not applicable
     if platform.system() == 'Windows':
         print("\n📦 Skipping permission tests (Windows platform)")
+        return
+
+    # Skip when running as root - root can override permission restrictions
+    if hasattr(os, 'geteuid') and os.geteuid() == 0:
+        print("\n📦 Skipping permission tests (running as root)")
         return
 
     print("\n📦 Testing permission error fail-open behavior...")


### PR DESCRIPTION
## Summary
Adds 12 comprehensive permission error tests to validate fail-open behavior across three critical modules: `registry_client`, `state_storage`, and `message_dedup_cache`.

## Changes
- **New test function**: `test_permission_errors_fail_open()` with 12 test cases
- **Platform handling**: Automatically skips on Windows (POSIX permissions not applicable)
- **Real permission errors**: Uses `chmod()` to create actual permission-denied scenarios
- **Robust cleanup**: try/except guards around all cleanup code to prevent masking test failures

## Test Coverage
### registry_client.py (4 tests)
1. Read-only directory preventing writes (atomic write pattern)
2. Unreadable files returning empty registry
3. File creation blocked in read-only directories
4. Write-only files failing gracefully on read

### state_storage.py (4 tests)
5. Read-only state files handled without crashes
6. Unreadable files returning empty state
7. Save operations in read-only directories failing silently
8. Delete operations gracefully handling permission denial

### message_dedup_cache.py (4 tests)
9. Read-only cache files returning True (show message)
10. Unreadable caches failing open properly
11. Cache creation in read-only directories handled gracefully
12. Write-only files treated as cache misses

## Code Quality Improvements
After pre-commit review:
- Fixed state assertions to use correct `'requirements'` key (was accidentally using `'satisfied'`)
- Added cleanup guards (try/except) around all `chmod()` calls to prevent cleanup failures from masking test failures
- Simplified exception handling in tests 5, 7, 8 to avoid hiding programming bugs

## Test Results
```bash
Results: 485/485 tests passed
```
All existing tests pass plus 12 new permission error tests.

## Closes
Fixes #13

## Test Plan
- [x] All 485 tests pass on macOS (POSIX system)
- [x] Tests skip gracefully on Windows
- [x] Pre-commit code review completed and issues addressed
- [x] Cleanup code verified to not leave test artifacts