### PR TITLE
feat(config): add project config modification support

### DIFF
--- a/hooks/requirements-cli.py
+++ b/hooks/requirements-cli.py
@@ -1802,11 +1802,14 @@ def cmd_config(args) -> int:
                 requirement_overrides={requirement_name: updates}
             )
         else:
-            # For project config, need to write differently
-            # For now, only support local (will add project support later)
-            print(warning("⚠️  Project config modification not yet implemented"))
-            print(dim("   Use --local flag to modify local config"))
-            return 1
+            # Project config modification
+            try:
+                file_path = config.write_project_override(
+                    requirement_overrides={requirement_name: updates}
+                )
+            except ImportError as e:
+                print(error(f"❌ {e}"), file=sys.stderr)
+                return 1
 
         print(success(f"✅ Updated {requirement_name}"))
         print(dim(f"   Modified: {file_path}"))


### PR DESCRIPTION
## Summary
Implements project config modification for `req config` command, enabling users to modify `.claude/requirements.yaml` (version-controlled, team-shared) in addition to existing local config support.

## Implementation
- ✅ Added `write_project_config()` helper function in config.py
- ✅ Added `write_project_override()` method to RequirementsConfig class
- ✅ Updated CLI to call `write_project_override()` for `--project` flag
- ✅ Uses atomic writes (temp file + rename) to prevent corruption
- ✅ Automatically preserves/adds inherit flag for project configs
- ✅ Requires PyYAML (no JSON fallback, matches req init behavior)

## Key Features
- **Deep merge**: Inherits all fields from global + project overrides
- **Preserves structure**: Maintains existing config (hooks, requirements, etc.)
- **Inherit flag handling**: Defaults to `true` for project configs
- **Clear error messages**: Helpful PyYAML installation prompt if missing

## Testing
- ✅ Added `test_write_project_config()` with 24 unit test cases
- ✅ Added `test_cli_config_project_modify()` with 5 integration tests
- ✅ All 514 tests pass (including 29 new tests)
- ✅ Manual testing verified end-to-end functionality
- ✅ Pre-commit review completed (code-reviewer + silent-failure-hunter)

## Example Usage
```bash
req config adr_reviewed --project --set adr_path=/docs/adr --yes
```

Output:
```
✅ Updated adr_reviewed
   Modified: .claude/requirements.yaml
```

## Before/After
**Before:** `req config --project` showed "⚠️ Project config modification not yet implemented"

**After:** Fully functional project config modification with deep merge support

## Files Changed
- `hooks/lib/config.py` (+149 lines)
- `hooks/requirements-cli.py` (+8, -5 lines)
- `hooks/test_requirements.py` (+205 lines)

## Test Plan
- [x] Run full test suite: `python3 hooks/test_requirements.py` ✅ 514/514 passed
- [x] Test project config creation from scratch
- [x] Test updating existing project config
- [x] Test inherit flag preservation
- [x] Test hooks section preservation
- [x] Test requirement merging (bool and dict formats)
- [x] Test CLI integration end-to-end
- [x] Test deep merge with global config
- [x] Manual verification of `req config --project --set`