### PR TITLE
feat: Add cross-project feature upgrade system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,9 +338,46 @@ req learning rollback 3   # Undo update #3
 - **User approval**: All updates require user approval before applying
 - **Rollback capable**: Every change recorded with previous content hash
 
+## Cross-Project Feature Upgrade
+
+The `req upgrade` command helps discover and adopt new framework features across all projects on your machine.
+
+### Usage
+
+```bash
+req upgrade scan               # Scan machine for projects using the framework
+req upgrade status             # Show feature status for current project
+req upgrade status --all       # Show all tracked projects (brief)
+req upgrade recommend          # Generate YAML snippets for missing features
+req upgrade recommend -f NAME  # Show snippet for specific feature
+```
+
+### How It Works
+
+1. **Project Registry**: Stores discovered projects at `~/.claude/project_registry.json`
+2. **Feature Catalog**: Tracks all available features with version info and YAML examples
+3. **Auto-Registration**: Projects are registered when sessions start (no manual scan needed)
+
+### Example
+
+```bash
+$ req upgrade status
+Feature Status: /Users/harm/Work/my-project
+────────────────────────────────────────────────
+  Requirements:
+    commit_plan               ✓ Enabled
+    session_learning          ○ Not configured
+────────────────────────────────────────────────
+  Enabled: 2/12 features
+
+$ req upgrade recommend --feature session_learning
+# Shows ready-to-copy YAML snippet
+```
+
 ## Additional Documentation
 - `DEVELOPMENT.md` - Comprehensive development guide with detailed implementation notes
 - `docs/adr/` - Architecture Decision Records documenting key design decisions
   - ADR-004: Guard requirement strategy
   - ADR-008: CLAUDE.md weekly maintenance process
+  - ADR-010: Cross-project feature upgrade system
 - `plugins/requirements-framework/README.md` - Plugin architecture with agents, commands, and skills

--- a/docs/README-REQUIREMENTS-FRAMEWORK.md
+++ b/docs/README-REQUIREMENTS-FRAMEWORK.md
@@ -332,6 +332,12 @@ req sessions
 
 # Cleanup stale state
 req prune
+
+# Cross-project feature upgrade
+req upgrade scan               # Scan machine for projects
+req upgrade status             # Show feature status for current project
+req upgrade status --all       # Show all tracked projects
+req upgrade recommend          # Generate YAML for missing features
 ```
 
 ## Scope Types
@@ -528,6 +534,7 @@ requirements:
 
 ## Version History
 
+- **v2.4** - **Cross-project feature upgrade** - `req upgrade` command for discovering and adopting new features across projects
 - **v2.3** - **`satisfied_by_skill` field** - Connect project skills to auto-satisfy requirements
 - **v2.2** - Full session lifecycle hooks (SessionStart, Stop, SessionEnd)
 - **v2.1** - Message deduplication for parallel tool calls
@@ -554,6 +561,7 @@ Framework code lives in `~/.claude/hooks/`. To update:
 - **Progress**: `~/.claude/requirements-framework-progress.json`
 - **Log File**: `~/.claude/requirements.log`
 - **Session Registry**: `~/.claude/sessions.json`
+- **Project Registry**: `~/.claude/project_registry.json`
 
 ---
 

--- a/docs/adr/ADR-010-cross-project-feature-upgrade.md
+++ b/docs/adr/ADR-010-cross-project-feature-upgrade.md
@@ -1,0 +1,86 @@
+# ADR-010: Cross-Project Feature Upgrade System
+
+## Status
+Approved (2026-01-21)
+
+## Context
+
+When the requirements framework plugin is updated with new features (like `session_learning`), there's no way to:
+1. Discover all projects using the plugin on a machine
+2. Show which features are available vs. configured per project
+3. Recommend how to integrate new features into existing projects
+
+Users have to manually remember which projects use the framework and individually check each one for missing features. This becomes tedious as the framework grows and more features are added.
+
+## Decision
+
+**Implement a `req upgrade` command that tracks projects machine-wide and helps users adopt new features.**
+
+### Architecture
+
+#### Feature Catalog (`hooks/lib/feature_catalog.py`)
+A comprehensive catalog of all framework features with metadata:
+- Name, description, category (requirements/guards/hooks)
+- Config path (e.g., `requirements.commit_plan`, `hooks.session_learning`)
+- Version introduced (for "new since" queries)
+- Example YAML snippets for integration
+
+#### Project Registry (`hooks/lib/project_registry.py`)
+Machine-wide tracking of projects in `~/.claude/project_registry.json`:
+- Stores discovered project paths
+- Records which features each project has configured
+- Tracks last-seen timestamps for stale detection
+
+#### CLI Commands
+```
+req upgrade scan               # Scan machine for projects
+req upgrade status             # Show features for current project
+req upgrade status --all       # Show all tracked projects
+req upgrade recommend          # Generate YAML snippets for missing features
+req upgrade recommend -f NAME  # Show snippet for specific feature
+```
+
+### Auto-Registration
+Projects are opportunistically registered when sessions start (in `handle-session-start.py`), keeping the registry fresh without requiring explicit scans.
+
+## Consequences
+
+### Positive
+- Users can discover all framework-enabled projects on their machine
+- Easy to see which features are missing from each project
+- Ready-to-copy YAML snippets reduce integration friction
+- Auto-registration keeps the registry current during normal use
+
+### Negative
+- Additional storage (~1KB JSON file in `~/.claude/`)
+- Slight overhead during session start (one file write)
+
+### Neutral
+- Scanning uses default paths (`~/Projects`, `~/Work`, `~/Code`, `~/Developer`, `~/dev`, `~/Tools`)
+- Max scan depth of 4 levels prevents filesystem overload
+
+## Implementation Notes
+
+1. **Fail-open design**: All registry operations fail silently to never block workflow
+2. **Atomic writes**: Uses same pattern as session registry (temp file + rename)
+3. **Feature detection**: Navigates config paths to detect enabled vs. configured features
+4. **Version tracking**: Features include `introduced` field for "new since X" queries
+
+## Example Output
+
+```
+$ req upgrade status
+Feature Status: /Users/harm/Work/my-project
+────────────────────────────────────────────────────────────
+
+  Requirements:
+    commit_plan               ✓ Enabled
+    adr_reviewed              ✓ Enabled
+    session_learning          ○ Not configured
+      └─ Analyze sessions to improve future efficiency
+
+────────────────────────────────────────────────────────────
+  Enabled: 2/12 features
+
+Run 'req upgrade recommend' to see integration snippets
+```

--- a/hooks/lib/feature_catalog.py
+++ b/hooks/lib/feature_catalog.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""
+Feature Catalog Module
+
+Provides a comprehensive catalog of all available framework features
+(both requirements and hooks) with metadata for discovery and upgrade workflows.
+
+This module enables:
+- Detecting which features are configured in a project
+- Identifying missing/new features
+- Generating YAML snippets for feature integration
+
+Usage:
+    from feature_catalog import (
+        get_all_features,
+        detect_configured_features,
+        get_missing_features,
+        get_feature_yaml
+    )
+
+    # Get all available features
+    features = get_all_features()
+
+    # Detect what's configured
+    configured = detect_configured_features(config)
+
+    # Find missing features
+    missing = get_missing_features(config)
+
+    # Get YAML snippet for a feature
+    yaml = get_feature_yaml('session_learning')
+"""
+from typing import Any, Dict, List, Optional
+
+# Feature categories for organization
+CATEGORY_REQUIREMENTS = "requirements"
+CATEGORY_HOOKS = "hooks"
+CATEGORY_GUARDS = "guards"
+
+# Feature catalog - comprehensive list of all framework features
+FEATURE_CATALOG: Dict[str, Dict[str, Any]] = {
+    # =========================================================================
+    # REQUIREMENTS
+    # =========================================================================
+    "commit_plan": {
+        "name": "Commit Planning",
+        "category": CATEGORY_REQUIREMENTS,
+        "config_path": "requirements.commit_plan",
+        "description": "Require planning before code changes",
+        "introduced": "1.0",
+        "default_enabled": True,
+        "example_yaml": """requirements:
+  commit_plan:
+    enabled: true
+    type: blocking
+    scope: session
+    description: "Ensures an atomic commit strategy exists before implementation."
+    trigger_tools:
+      - Edit
+      - Write
+      - MultiEdit
+    auto_resolve_skill: "requirements-framework:plan-review"
+    message: |
+      ## Blocked: commit_plan
+
+      **Execute**: `/requirements-framework:plan-review`
+
+      ---
+      Fallback: `req satisfy commit_plan`""",
+    },
+    "adr_reviewed": {
+        "name": "ADR Review",
+        "category": CATEGORY_REQUIREMENTS,
+        "config_path": "requirements.adr_reviewed",
+        "description": "Check Architecture Decision Records before changes",
+        "introduced": "1.0",
+        "default_enabled": True,
+        "example_yaml": """requirements:
+  adr_reviewed:
+    enabled: true
+    type: blocking
+    scope: session
+    description: "Ensures changes align with Architecture Decision Records."
+    trigger_tools:
+      - Edit
+      - Write
+      - MultiEdit
+    auto_resolve_skill: "requirements-framework:plan-review"
+    message: |
+      ## Blocked: adr_reviewed
+
+      **Execute**: `/requirements-framework:plan-review`
+
+      ---
+      Fallback: `req satisfy adr_reviewed`""",
+    },
+    "pre_commit_review": {
+        "name": "Pre-Commit Review",
+        "category": CATEGORY_REQUIREMENTS,
+        "config_path": "requirements.pre_commit_review",
+        "description": "Code review before each commit",
+        "introduced": "1.0",
+        "default_enabled": True,
+        "example_yaml": """requirements:
+  pre_commit_review:
+    enabled: true
+    type: blocking
+    scope: single_use
+    description: "Code review before each commit."
+    trigger_tools:
+      - tool: Bash
+        command_pattern: "git\\\\s+(commit|cherry-pick|revert|merge)"
+    auto_resolve_skill: "requirements-framework:pre-commit"
+    satisfied_by_skill: 'requirements-framework:pre-commit'
+    message: |
+      ## Blocked: pre_commit_review
+
+      **Execute**: `/requirements-framework:pre-commit`
+
+      ---
+      Fallback: `req satisfy pre_commit_review`""",
+    },
+    "pre_pr_review": {
+        "name": "Pre-PR Review",
+        "category": CATEGORY_REQUIREMENTS,
+        "config_path": "requirements.pre_pr_review",
+        "description": "Comprehensive quality check before PR creation",
+        "introduced": "1.0",
+        "default_enabled": True,
+        "example_yaml": """requirements:
+  pre_pr_review:
+    enabled: true
+    type: blocking
+    scope: single_use
+    description: "Comprehensive quality review before PR creation."
+    trigger_tools:
+      - tool: Bash
+        command_pattern: "gh\\\\s+pr\\\\s+create"
+    auto_resolve_skill: "requirements-framework:quality-check"
+    satisfied_by_skill: 'requirements-framework:quality-check'
+    message: |
+      ## Blocked: pre_pr_review
+
+      **Execute**: `/requirements-framework:quality-check`
+
+      ---
+      Fallback: `req satisfy pre_pr_review`""",
+    },
+    "codex_reviewer": {
+        "name": "Codex AI Review",
+        "category": CATEGORY_REQUIREMENTS,
+        "config_path": "requirements.codex_reviewer",
+        "description": "AI-powered code review via OpenAI Codex CLI",
+        "introduced": "1.0",
+        "default_enabled": True,
+        "example_yaml": """requirements:
+  codex_reviewer:
+    enabled: true
+    type: blocking
+    scope: single_use
+    description: "AI-powered code review via OpenAI Codex CLI."
+    trigger_tools:
+      - tool: Bash
+        command_pattern: "gh\\\\s+pr\\\\s+create"
+    auto_resolve_skill: "requirements-framework:codex-review"
+    satisfied_by_skill: 'requirements-framework:codex-review'
+    message: |
+      ## Blocked: codex_reviewer
+
+      **Execute**: `/requirements-framework:codex-review`
+
+      ---
+      Fallback: `req satisfy codex_reviewer`""",
+    },
+    "github_ticket": {
+        "name": "GitHub Ticket",
+        "category": CATEGORY_REQUIREMENTS,
+        "config_path": "requirements.github_ticket",
+        "description": "Link work to GitHub issue tracking",
+        "introduced": "1.0",
+        "default_enabled": False,
+        "example_yaml": """requirements:
+  github_ticket:
+    enabled: true
+    type: blocking
+    scope: branch
+    description: "Links work to GitHub issue tracking."
+    trigger_tools:
+      - Edit
+      - Write
+      - MultiEdit
+    message: |
+      ## Blocked: github_ticket
+
+      No GitHub issue linked to this branch.
+
+      ---
+      Fallback: `req satisfy github_ticket --metadata '{"ticket":"#1234"}'`""",
+    },
+    # =========================================================================
+    # DYNAMIC REQUIREMENTS
+    # =========================================================================
+    "branch_size_limit": {
+        "name": "Branch Size Limits",
+        "category": CATEGORY_REQUIREMENTS,
+        "config_path": "requirements.branch_size_limit",
+        "description": "Automatically calculate and enforce PR size limits",
+        "introduced": "1.0",
+        "default_enabled": True,
+        "example_yaml": """requirements:
+  branch_size_limit:
+    enabled: true
+    type: dynamic
+    calculator: branch_size_calculator
+    description: "Automatically calculates branch size and enforces limits."
+    scope: session
+    trigger_tools:
+      - Edit
+      - Write
+      - MultiEdit
+    cache_ttl: 60
+    approval_ttl: 3600
+    thresholds:
+      warn: 250
+      block: 400
+    blocking_message: |
+      ## Blocked: branch_size_limit
+
+      Branch has **{total}** line changes (limit: {block_threshold}).
+
+      ---
+      Override: `req approve branch_size_limit`""",
+    },
+    # =========================================================================
+    # GUARDS
+    # =========================================================================
+    "protected_branch": {
+        "name": "Protected Branches",
+        "category": CATEGORY_GUARDS,
+        "config_path": "requirements.protected_branch",
+        "description": "Prevent direct edits on main/master branches",
+        "introduced": "1.0",
+        "default_enabled": True,
+        "example_yaml": """requirements:
+  protected_branch:
+    enabled: true
+    type: guard
+    guard_type: protected_branch
+    description: "Prevents direct edits on main/master branches."
+    protected_branches:
+      - master
+      - main
+    trigger_tools:
+      - Edit
+      - Write
+      - MultiEdit
+    message: |
+      ## Blocked: protected_branch
+
+      Cannot edit files on protected branch `{branch}`.
+
+      **Actions**:
+      1. Create feature branch: `git checkout -b feature/your-feature-name`
+      2. Emergency override: `req approve protected_branch`""",
+    },
+    "single_session_per_project": {
+        "name": "Single Session Guard",
+        "category": CATEGORY_GUARDS,
+        "config_path": "requirements.single_session_per_project",
+        "description": "Prevent multiple sessions editing same project",
+        "introduced": "1.0",
+        "default_enabled": False,
+        "example_yaml": """requirements:
+  single_session_per_project:
+    enabled: true
+    type: guard
+    guard_type: single_session
+    description: "Prevents multiple sessions from editing same project."
+    scope: session
+    trigger_tools:
+      - Edit
+      - Write
+      - MultiEdit
+    message: |
+      ## Blocked: single_session_per_project
+
+      Another Claude Code session is active on this project.
+
+      ---
+      Override: `req approve single_session_per_project`""",
+    },
+    # =========================================================================
+    # HOOKS
+    # =========================================================================
+    "session_learning": {
+        "name": "Session Learning",
+        "category": CATEGORY_HOOKS,
+        "config_path": "hooks.session_learning",
+        "description": "Analyze sessions to improve future efficiency",
+        "introduced": "1.1",
+        "default_enabled": False,
+        "example_yaml": """hooks:
+  session_learning:
+    enabled: true
+    prompt_on_stop: true
+    min_tool_uses: 5""",
+    },
+    "session_start": {
+        "name": "Session Start Context",
+        "category": CATEGORY_HOOKS,
+        "config_path": "hooks.session_start",
+        "description": "Inject requirement context at session start",
+        "introduced": "1.0",
+        "default_enabled": True,
+        "example_yaml": """hooks:
+  session_start:
+    inject_context: true
+    injection_mode: auto""",
+    },
+    "stop_verification": {
+        "name": "Stop Verification",
+        "category": CATEGORY_HOOKS,
+        "config_path": "hooks.stop",
+        "description": "Verify requirements before session ends",
+        "introduced": "1.0",
+        "default_enabled": True,
+        "example_yaml": """hooks:
+  stop:
+    verify_requirements: true""",
+    },
+}
+
+
+def get_all_features() -> Dict[str, Dict[str, Any]]:
+    """
+    Get the complete feature catalog.
+
+    Returns:
+        Dict mapping feature names to their metadata
+    """
+    return FEATURE_CATALOG.copy()
+
+
+def get_features_by_category(category: str) -> Dict[str, Dict[str, Any]]:
+    """
+    Get features filtered by category.
+
+    Args:
+        category: One of 'requirements', 'hooks', 'guards'
+
+    Returns:
+        Dict of features in that category
+    """
+    return {
+        name: info
+        for name, info in FEATURE_CATALOG.items()
+        if info.get("category") == category
+    }
+
+
+def detect_configured_features(config: Dict[str, Any]) -> Dict[str, bool]:
+    """
+    Check which features are configured in a config dict.
+
+    Args:
+        config: Loaded requirements config dict
+
+    Returns:
+        Dict mapping feature names to enabled status (True/False/None if not configured)
+    """
+    result: Dict[str, bool] = {}
+
+    for feature_name, feature_info in FEATURE_CATALOG.items():
+        config_path = feature_info.get("config_path", "")
+        parts = config_path.split(".")
+
+        # Navigate config path
+        current = config
+        found = True
+        for part in parts:
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            else:
+                found = False
+                break
+
+        if found and isinstance(current, dict):
+            # Feature is configured - check if enabled
+            result[feature_name] = current.get("enabled", True)
+        else:
+            # Feature not configured
+            result[feature_name] = False
+
+    return result
+
+
+def get_missing_features(config: Dict[str, Any]) -> List[str]:
+    """
+    Get list of features not configured in a config.
+
+    Args:
+        config: Loaded requirements config dict
+
+    Returns:
+        List of feature names that are not configured
+    """
+    configured = detect_configured_features(config)
+    return [name for name, enabled in configured.items() if not enabled]
+
+
+def get_enabled_features(config: Dict[str, Any]) -> List[str]:
+    """
+    Get list of features that are configured and enabled.
+
+    Args:
+        config: Loaded requirements config dict
+
+    Returns:
+        List of enabled feature names
+    """
+    configured = detect_configured_features(config)
+    return [name for name, enabled in configured.items() if enabled]
+
+
+def get_feature_yaml(feature_name: str) -> Optional[str]:
+    """
+    Get the example YAML snippet for a feature.
+
+    Args:
+        feature_name: Name of the feature
+
+    Returns:
+        YAML snippet string, or None if feature not found
+    """
+    feature = FEATURE_CATALOG.get(feature_name)
+    if feature:
+        return feature.get("example_yaml")
+    return None
+
+
+def get_feature_info(feature_name: str) -> Optional[Dict[str, Any]]:
+    """
+    Get full metadata for a feature.
+
+    Args:
+        feature_name: Name of the feature
+
+    Returns:
+        Feature metadata dict, or None if not found
+    """
+    return FEATURE_CATALOG.get(feature_name)
+
+
+def get_new_features_since(version: str) -> List[str]:
+    """
+    Get features introduced after a given version.
+
+    Args:
+        version: Version string (e.g., "1.0")
+
+    Returns:
+        List of feature names introduced after that version
+    """
+    # Simple version comparison (assumes major.minor format)
+    try:
+        major, minor = map(int, version.split("."))
+        target_version = (major, minor)
+    except ValueError:
+        return []
+
+    new_features = []
+    for name, info in FEATURE_CATALOG.items():
+        introduced = info.get("introduced", "1.0")
+        try:
+            intro_major, intro_minor = map(int, introduced.split("."))
+            if (intro_major, intro_minor) > target_version:
+                new_features.append(name)
+        except ValueError:
+            continue
+
+    return new_features

--- a/hooks/lib/project_registry.py
+++ b/hooks/lib/project_registry.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""
+Project Registry Module
+
+Tracks all projects using the requirements framework across the machine.
+Enables cross-project feature discovery and upgrade workflows.
+
+Storage: ~/.claude/project_registry.json
+
+Registry format:
+{
+    "version": "1.0",
+    "updated_at": 1234567890,
+    "projects": {
+        "/path/to/project": {
+            "discovered_at": 1234567890,
+            "last_seen": 1234567890,
+            "has_global_inherit": true,
+            "configured_features": ["commit_plan", "adr_reviewed"]
+        }
+    }
+}
+
+Usage:
+    from project_registry import ProjectRegistry
+
+    registry = ProjectRegistry()
+
+    # Scan for projects
+    found = registry.scan_for_projects([Path.home()])
+
+    # Register current project
+    registry.register_project("/path/to/project", ["commit_plan"])
+
+    # List all known projects
+    projects = registry.list_projects()
+
+    # Prune stale entries
+    removed = registry.prune_stale()
+"""
+import fcntl
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+from logger import get_logger
+
+# Default registry location
+DEFAULT_REGISTRY_PATH = Path.home() / ".claude" / "project_registry.json"
+
+# Default paths to scan for projects
+DEFAULT_SCAN_PATHS = [
+    Path.home() / "Projects",
+    Path.home() / "Work",
+    Path.home() / "Code",
+    Path.home() / "Developer",
+    Path.home() / "dev",
+    Path.home() / "Tools",
+]
+
+# Maximum scan depth to prevent scanning entire filesystem
+MAX_SCAN_DEPTH = 4
+
+
+class ProjectRegistry:
+    """
+    Registry for tracking projects using the requirements framework.
+
+    Stores project information in a JSON file at ~/.claude/project_registry.json.
+    Uses atomic writes with file locking for safe concurrent access.
+    """
+
+    def __init__(self, registry_path: Optional[Path] = None):
+        """
+        Initialize registry client.
+
+        Args:
+            registry_path: Path to registry file. Defaults to ~/.claude/project_registry.json
+        """
+        self.registry_path = registry_path or DEFAULT_REGISTRY_PATH
+
+    def read(self) -> Dict[str, Any]:
+        """
+        Read registry with shared lock.
+
+        Returns:
+            Registry dict with 'version', 'updated_at', and 'projects' keys.
+            Returns empty registry on errors.
+
+        Note:
+            Fails open - errors don't propagate.
+        """
+        if not self.registry_path.exists():
+            return {"version": "1.0", "updated_at": 0, "projects": {}}
+
+        try:
+            with open(self.registry_path, 'r') as f:
+                fcntl.flock(f, fcntl.LOCK_SH)  # Shared lock for reading
+                try:
+                    registry = json.load(f)
+                finally:
+                    fcntl.flock(f, fcntl.LOCK_UN)
+            return registry
+        except json.JSONDecodeError as e:
+            get_logger().warning(f"Registry corrupted ({self.registry_path}): {e}")
+            return {"version": "1.0", "updated_at": 0, "projects": {}}
+        except (OSError, IOError) as e:
+            get_logger().warning(f"Registry read error ({self.registry_path}): {e}")
+            return {"version": "1.0", "updated_at": 0, "projects": {}}
+
+    def write(self, registry: Dict[str, Any]) -> bool:
+        """
+        Write registry atomically with exclusive lock.
+
+        Uses atomic write pattern:
+        1. Write to temp file with exclusive lock
+        2. fsync to ensure data on disk
+        3. Atomic rename (POSIX guarantee)
+
+        Args:
+            registry: Registry dict to write
+
+        Returns:
+            True if write succeeded, False on error
+
+        Note:
+            Fails open - errors don't raise.
+        """
+        # Ensure parent directory exists
+        self.registry_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Update timestamp
+        registry["updated_at"] = int(time.time())
+
+        temp_path = self.registry_path.with_suffix('.tmp')
+
+        try:
+            with open(temp_path, 'w') as f:
+                fcntl.flock(f, fcntl.LOCK_EX)  # Exclusive lock for writing
+                try:
+                    json.dump(registry, f, indent=2)
+                    f.flush()
+                    os.fsync(f.fileno())  # Ensure written to disk
+                finally:
+                    fcntl.flock(f, fcntl.LOCK_UN)
+
+            # Atomic rename (POSIX guarantees atomicity)
+            temp_path.rename(self.registry_path)
+            return True
+        except (OSError, IOError) as e:
+            get_logger().warning(f"Registry write error ({self.registry_path}): {e}")
+            if temp_path.exists():
+                try:
+                    temp_path.unlink()
+                except OSError:
+                    pass
+            return False
+
+    def scan_for_projects(
+        self,
+        root_paths: Optional[List[Path]] = None,
+        max_depth: int = MAX_SCAN_DEPTH
+    ) -> List[str]:
+        """
+        Scan directories for projects with .claude/requirements.yaml files.
+
+        Args:
+            root_paths: Directories to scan. Uses defaults if not specified.
+            max_depth: Maximum directory depth to scan.
+
+        Returns:
+            List of absolute paths to discovered projects.
+        """
+        if root_paths is None:
+            root_paths = [p for p in DEFAULT_SCAN_PATHS if p.exists()]
+
+        discovered: Set[str] = set()
+
+        for root in root_paths:
+            if not root.exists():
+                continue
+            self._scan_directory(root, discovered, 0, max_depth)
+
+        return sorted(discovered)
+
+    def _scan_directory(
+        self,
+        directory: Path,
+        discovered: Set[str],
+        current_depth: int,
+        max_depth: int
+    ) -> None:
+        """
+        Recursively scan a directory for requirements configs.
+
+        Args:
+            directory: Directory to scan
+            discovered: Set to add discovered projects to
+            current_depth: Current recursion depth
+            max_depth: Maximum recursion depth
+        """
+        if current_depth > max_depth:
+            return
+
+        try:
+            # Check for requirements config in this directory
+            config_path = directory / ".claude" / "requirements.yaml"
+            if config_path.exists():
+                discovered.add(str(directory.resolve()))
+                # Don't recurse into discovered projects
+                return
+
+            # Skip common non-project directories
+            skip_dirs = {
+                '.git', 'node_modules', 'venv', '.venv', '__pycache__',
+                'build', 'dist', '.next', '.cache', 'vendor', 'target'
+            }
+
+            # Recurse into subdirectories
+            for item in directory.iterdir():
+                if item.is_dir() and item.name not in skip_dirs and not item.name.startswith('.'):
+                    self._scan_directory(item, discovered, current_depth + 1, max_depth)
+
+        except PermissionError:
+            # Skip directories we can't read
+            pass
+        except OSError as e:
+            get_logger().debug(f"Error scanning {directory}: {e}")
+
+    def register_project(
+        self,
+        project_path: str,
+        configured_features: Optional[List[str]] = None,
+        has_global_inherit: bool = False
+    ) -> bool:
+        """
+        Register or update a project in the registry.
+
+        Args:
+            project_path: Absolute path to project directory
+            configured_features: List of enabled feature names
+            has_global_inherit: Whether project inherits from global config
+
+        Returns:
+            True if registration succeeded
+        """
+        registry = self.read()
+        now = int(time.time())
+
+        project_path = str(Path(project_path).resolve())
+
+        if project_path in registry["projects"]:
+            # Update existing entry
+            registry["projects"][project_path].update({
+                "last_seen": now,
+                "configured_features": configured_features or [],
+                "has_global_inherit": has_global_inherit,
+            })
+        else:
+            # New entry
+            registry["projects"][project_path] = {
+                "discovered_at": now,
+                "last_seen": now,
+                "configured_features": configured_features or [],
+                "has_global_inherit": has_global_inherit,
+            }
+
+        return self.write(registry)
+
+    def list_projects(self) -> List[Dict[str, Any]]:
+        """
+        Get all known projects with their metadata.
+
+        Returns:
+            List of project info dicts with 'path' key added.
+        """
+        registry = self.read()
+        projects = []
+
+        for path, info in registry.get("projects", {}).items():
+            project = info.copy()
+            project["path"] = path
+            projects.append(project)
+
+        # Sort by last_seen (most recent first)
+        projects.sort(key=lambda p: p.get("last_seen", 0), reverse=True)
+        return projects
+
+    def get_project(self, project_path: str) -> Optional[Dict[str, Any]]:
+        """
+        Get info for a specific project.
+
+        Args:
+            project_path: Path to project
+
+        Returns:
+            Project info dict or None if not found
+        """
+        registry = self.read()
+        project_path = str(Path(project_path).resolve())
+        info = registry.get("projects", {}).get(project_path)
+        if info:
+            info = info.copy()
+            info["path"] = project_path
+        return info
+
+    def prune_stale(self) -> int:
+        """
+        Remove projects where the config file no longer exists.
+
+        Returns:
+            Number of entries removed.
+        """
+        registry = self.read()
+        projects = registry.get("projects", {})
+
+        to_remove = []
+        for path in projects:
+            config_path = Path(path) / ".claude" / "requirements.yaml"
+            if not config_path.exists():
+                to_remove.append(path)
+
+        for path in to_remove:
+            del registry["projects"][path]
+
+        if to_remove:
+            self.write(registry)
+
+        return len(to_remove)
+
+    def update_and_scan(self, scan_paths: Optional[List[Path]] = None) -> Dict[str, Any]:
+        """
+        Scan for projects and update registry, returning summary.
+
+        Args:
+            scan_paths: Paths to scan (uses defaults if None)
+
+        Returns:
+            Dict with 'new', 'updated', 'removed' counts
+        """
+        registry = self.read()
+        existing_paths = set(registry.get("projects", {}).keys())
+
+        # Scan for projects
+        discovered = set(self.scan_for_projects(scan_paths))
+
+        # Categorize
+        new_projects = discovered - existing_paths
+        still_valid = discovered & existing_paths
+        removed = existing_paths - discovered
+
+        # Register new projects
+        from feature_catalog import detect_configured_features
+        from config import RequirementsConfig
+
+        for path in new_projects:
+            try:
+                config_obj = RequirementsConfig(project_dir=path)
+                raw_config = config_obj.get_raw_config()
+                features = detect_configured_features(raw_config)
+                enabled = [f for f, e in features.items() if e]
+                has_inherit = raw_config.get("inherit", False)
+                self.register_project(path, enabled, has_inherit)
+            except Exception as e:
+                get_logger().debug(f"Error loading config for {path}: {e}")
+                self.register_project(path, [], False)
+
+        # Re-read registry after registrations to get updated state
+        registry = self.read()
+
+        # Update timestamps for still-valid projects
+        now = int(time.time())
+        for path in still_valid:
+            if path in registry["projects"]:
+                registry["projects"][path]["last_seen"] = now
+
+        # Remove stale entries
+        for path in removed:
+            if path in registry["projects"]:
+                del registry["projects"][path]
+
+        # Only write if we have timestamp updates or removals
+        if still_valid or removed:
+            self.write(registry)
+
+        return {
+            "new": len(new_projects),
+            "updated": len(still_valid),
+            "removed": len(removed),
+            "total": len(discovered),
+        }


### PR DESCRIPTION
## Summary

- Adds `req upgrade` command to discover and adopt new framework features across all projects on a machine
- Introduces feature catalog (`feature_catalog.py`) with metadata for all 12 framework features
- Adds machine-wide project registry (`project_registry.py`) stored at `~/.claude/project_registry.json`
- Auto-registers projects at session start to keep registry fresh

## New CLI Commands

```bash
req upgrade scan               # Scan machine for projects
req upgrade status             # Show feature status for current project
req upgrade status --all       # Show all tracked projects
req upgrade recommend          # Generate YAML snippets for missing features
req upgrade recommend -f NAME  # Show snippet for specific feature
```

## Test plan

- [x] All 838 tests pass
- [x] Manual testing of `req upgrade scan` - finds projects correctly
- [x] Manual testing of `req upgrade status` - shows feature status
- [x] Manual testing of `req upgrade recommend` - generates valid YAML
- [x] Auto-registration at session start verified