### PR TITLE
fix: resolve NameError for undefined claude_dir in req verify

### DIFF
--- a/hooks/requirements-cli.py
+++ b/hooks/requirements-cli.py
@@ -974,7 +974,8 @@ def cmd_verify(args) -> int:
         "requirements-cli.py"
     ]
 
-    hooks_dir = Path.home() / '.claude' / 'hooks'
+    claude_dir = Path.home() / '.claude'
+    hooks_dir = claude_dir / 'hooks'
     missing_files = []
     for hook_file in hook_files:
         hook_path = hooks_dir / hook_file


### PR DESCRIPTION
## Summary

- `cmd_verify` in `requirements-cli.py` crashed with `NameError: name 'claude_dir' is not defined` because `hooks_dir` was built as a single path expression without defining the intermediate `claude_dir` variable needed by `_load_settings_file()`
- Fix derives `hooks_dir` from `claude_dir`, matching the pattern used in `cmd_init` and other functions
- All 926 tests pass; `req verify` completes successfully

## Test plan

- [x] `python3 hooks/test_requirements.py` — 926/926 pass
- [x] `req verify` — runs without NameError