### PR TITLE
feat: Dynamic skill path substitution in blocking messages

### DIFF
--- a/.claude/requirements.yaml
+++ b/.claude/requirements.yaml
@@ -14,7 +14,7 @@ requirements:
     message: |
       ## Blocked: commit_plan
 
-      **Execute**: `/requirements-framework:plan-review`
+      **Execute**: `/{auto_resolve_skill}`
 
       Creates atomic commit strategy and validates against ADRs.
     checklist:
@@ -34,7 +34,7 @@ requirements:
     message: |
       ## Blocked: adr_reviewed
 
-      **Execute**: `/requirements-framework:plan-review`
+      **Execute**: `/{auto_resolve_skill}`
 
       Runs adr-guardian agent to validate against Architecture Decision Records.
     checklist:
@@ -53,7 +53,7 @@ requirements:
     message: |
       ## Blocked: tdd_planned
 
-      **Execute**: `/requirements-framework:plan-review`
+      **Execute**: `/{auto_resolve_skill}`
 
       Validates TDD readiness: test strategy and test cases per feature.
     checklist:
@@ -143,7 +143,7 @@ requirements:
     message: |
       ## Blocked: pre_commit_review
 
-      **Execute**: `/requirements-framework:pre-commit`
+      **Execute**: `/{auto_resolve_skill}`
 
       Runs code-reviewer, silent-failure-hunter, and tool-validator agents.
     checklist:
@@ -163,7 +163,7 @@ requirements:
     message: |
       ## Blocked: pre_pr_review
 
-      **Execute**: `/requirements-framework:quality-check`
+      **Execute**: `/{auto_resolve_skill}`
 
       Comprehensive quality review with all 8 review agents.
     checklist:
@@ -183,7 +183,7 @@ requirements:
     message: |
       ## Blocked: codex_reviewer
 
-      **Execute**: `/requirements-framework:codex-review`
+      **Execute**: `/{auto_resolve_skill}`
 
       AI-powered code review via OpenAI Codex CLI.
     checklist:

--- a/examples/global-requirements.yaml
+++ b/examples/global-requirements.yaml
@@ -25,7 +25,7 @@ requirements:
     message: |
       ## Blocked: commit_plan
 
-      **Execute**: `/requirements-framework:plan-review`
+      **Execute**: `/{auto_resolve_skill}`
 
       Creates atomic commit strategy and validates against ADRs.
 
@@ -75,7 +75,7 @@ requirements:
     message: |
       ## Blocked: adr_reviewed
 
-      **Execute**: `/requirements-framework:plan-review`
+      **Execute**: `/{auto_resolve_skill}`
 
       Runs adr-guardian agent to validate against Architecture Decision Records.
 
@@ -100,7 +100,7 @@ requirements:
     message: |
       ## Blocked: tdd_planned
 
-      **Execute**: `/requirements-framework:plan-review`
+      **Execute**: `/{auto_resolve_skill}`
 
       Validates TDD readiness: test strategy and test cases per feature.
 
@@ -213,7 +213,7 @@ requirements:
     message: |
       ## Blocked: pre_commit_review
 
-      **Execute**: `/requirements-framework:pre-commit`
+      **Execute**: `/{auto_resolve_skill}`
 
       Runs code-reviewer, silent-failure-hunter, and tool-validator agents.
 
@@ -239,7 +239,7 @@ requirements:
     message: |
       ## Blocked: pre_pr_review
 
-      **Execute**: `/requirements-framework:quality-check`
+      **Execute**: `/{auto_resolve_skill}`
 
       Comprehensive quality review with all 8 review agents.
 
@@ -265,7 +265,7 @@ requirements:
     message: |
       ## Blocked: codex_reviewer
 
-      **Execute**: `/requirements-framework:codex-review`
+      **Execute**: `/{auto_resolve_skill}`
 
       AI-powered code review via OpenAI Codex CLI.
 
@@ -295,7 +295,7 @@ requirements:
 #     message: |
 #       ## Blocked: adr_plan_validation
 #
-#       **Execute**: `/requirements-framework:plan-review`
+#       **Execute**: `/{auto_resolve_skill}`
 #
 #       Validates plan against ADRs before implementation.
 #

--- a/hooks/lib/blocking_strategy.py
+++ b/hooks/lib/blocking_strategy.py
@@ -79,6 +79,9 @@ class BlockingRequirementStrategy(RequirementStrategy):
 
         session_id = context.get('session_id', 'unknown')
 
+        # Get auto_resolve_skill for message substitution
+        auto_resolve_skill = req_config.get('auto_resolve_skill', '') if req_config else ''
+
         # Try to use externalized messages from MessageLoader
         message_loader = self._get_message_loader(context)
         if message_loader:
@@ -89,6 +92,7 @@ class BlockingRequirementStrategy(RequirementStrategy):
                     session_id=session_id,
                     branch=context.get('branch', ''),
                     project_dir=context.get('project_dir', ''),
+                    auto_resolve_skill=auto_resolve_skill,
                 )
                 message = formatted.blocking_message
                 short_msg = formatted.short_message
@@ -103,6 +107,9 @@ class BlockingRequirementStrategy(RequirementStrategy):
         # Fall back to inline config message if no externalized message
         if not message and req_config:
             message = req_config.get('message', '')
+            if message:
+                message = message.replace('{auto_resolve_skill}', auto_resolve_skill)
+                message = message.replace('{session_id}', session_id)
 
         if not message:
             # Generate directive-first fallback message

--- a/hooks/lib/guard_strategy.py
+++ b/hooks/lib/guard_strategy.py
@@ -135,6 +135,9 @@ class GuardRequirementStrategy(RequirementStrategy):
         """
         session_id = context.get('session_id', 'unknown')
 
+        # Get auto_resolve_skill for message substitution
+        auto_resolve_skill = config.get_attribute(req_name, 'auto_resolve_skill', '')
+
         # Try to use externalized messages from MessageLoader
         message = None
         short_msg = None
@@ -148,6 +151,7 @@ class GuardRequirementStrategy(RequirementStrategy):
                     session_id=session_id,
                     branch=branch,
                     project_dir=context.get('project_dir', ''),
+                    auto_resolve_skill=auto_resolve_skill,
                 )
                 message = formatted.blocking_message
                 short_msg = formatted.short_message
@@ -161,8 +165,10 @@ class GuardRequirementStrategy(RequirementStrategy):
 
             if custom_message:
                 # Use configured message as-is (directive-first format)
-                # Substitute {branch} placeholder if present
+                # Substitute placeholders if present
                 message = custom_message.replace('{branch}', branch)
+                message = message.replace('{auto_resolve_skill}', auto_resolve_skill)
+                message = message.replace('{session_id}', session_id)
             else:
                 # Directive-first fallback
                 lines = [
@@ -250,6 +256,9 @@ class GuardRequirementStrategy(RequirementStrategy):
         session_id = context.get('session_id', 'unknown')
         project_dir = context.get('project_dir', 'unknown')
 
+        # Get auto_resolve_skill for message substitution
+        auto_resolve_skill = config.get_attribute(req_name, 'auto_resolve_skill', '')
+
         # Try to get short message from loader
         short_msg = None
         message_loader = self._get_message_loader(context)
@@ -260,6 +269,7 @@ class GuardRequirementStrategy(RequirementStrategy):
                     req_name=req_name,
                     session_id=session_id,
                     project_dir=project_dir,
+                    auto_resolve_skill=auto_resolve_skill,
                 )
                 short_msg = formatted.short_message
             except Exception:
@@ -272,8 +282,10 @@ class GuardRequirementStrategy(RequirementStrategy):
         custom_message = config.get_attribute(req_name, 'message', None)
 
         if custom_message:
-            # Use configured message as-is
-            message = custom_message
+            # Use configured message - substitute placeholders
+            message = custom_message.replace('{auto_resolve_skill}', auto_resolve_skill)
+            message = message.replace('{session_id}', session_id)
+            message = message.replace('{project_dir}', project_dir)
         else:
             # Directive-first fallback with session info
             import time


### PR DESCRIPTION
Replace hardcoded plugin-qualified skill paths with {auto_resolve_skill} placeholder in message templates and inline config. The auto_resolve_skill config field is now passed through the message formatting pipeline in both blocking and guard strategies, enabling single-source-of-truth skill paths that stay current when projects configure different skills.