### PR TITLE
feat: add human-readable team progress log for real-time visibility

### DIFF
--- a/hooks/handle-teammate-idle.py
+++ b/hooks/handle-teammate-idle.py
@@ -37,6 +37,21 @@ from config import RequirementsConfig
 from git_utils import resolve_project_root
 
 
+def append_progress_log(project_dir: str, event: str, detail: str) -> None:
+    """Append a line to team_progress.log (fail-open)."""
+    try:
+        from datetime import datetime
+        from state_storage import get_state_dir
+        log_dir = get_state_dir(project_dir)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / 'team_progress.log'
+        timestamp = datetime.now().strftime('%H:%M:%S')
+        with open(log_path, 'a') as f:
+            f.write(f"[{timestamp}] {event}  {detail}\n")
+    except Exception:
+        pass  # Fail-open
+
+
 def main() -> int:
     """Hook entry point."""
     logger = get_logger(base_context={"hook": "TeammateIdle"})
@@ -88,6 +103,9 @@ def main() -> int:
             team=team_name,
             session=session_id,
         )
+
+        # Append to human-readable progress log
+        append_progress_log(project_dir, "IDLE ", f"{teammate_name} paused  [{team_name}]")
 
         # Record in session metrics if available
         try:


### PR DESCRIPTION
Both TeammateIdle and TaskCompleted hooks now append progress lines to .git/requirements/team_progress.log, enabling users to monitor team reviews in real-time via `tail -f`. Fail-open design ensures log write failures never affect hook behavior.