### PR TITLE
fix: update stale plugin metadata and component counts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "description": "Local marketplace for requirements framework plugin development",
   "plugins": [{
     "name": "requirements-framework",
-    "version": "2.0.5",
+    "version": "2.1.0",
     "description": "Claude Code Requirements Framework - Workflow enforcement and code review",
     "source": "./plugins/requirements-framework"
   }]

--- a/github-issues-plugin/agents/issue-manager.md
+++ b/github-issues-plugin/agents/issue-manager.md
@@ -50,7 +50,7 @@ Custom field updates require project item editing via gh or GraphQL, which the a
 model: inherit
 color: cyan
 tools: ["Bash", "Read", "Write", "Grep", "Glob"]
-git_hash: f23d317
+git_hash: 71ee5ae
 ---
 
 You are a GitHub Issues Management specialist. You handle the complete lifecycle of GitHub issues with deep integration into GitHub Projects v2.

--- a/plugins/requirements-framework/README.md
+++ b/plugins/requirements-framework/README.md
@@ -7,8 +7,8 @@ Comprehensive workflow enforcement and code review automation for Claude Code.
 This plugin provides workflow enforcement, code review agents, and management tools that integrate seamlessly with the Requirements Framework hooks.
 
 **Key Features**:
-- ✨ **17 specialized review agents** - From tool validation to backward compatibility checking
-- 🎯 **2 orchestrator commands** - Fast pre-commit and thorough pre-PR workflows
+- ✨ **16 specialized review agents** - From tool validation to backward compatibility checking
+- 🎯 **8 orchestrator commands** - From pre-commit to architecture review workflows
 - 📋 **5 management skills** - Status reporting, usage help, and framework development
 - 🔗 **Hook integration** - Auto-satisfies requirements when commands complete
 - 🧪 **TDD-first** - 447 passing tests ensure reliability
@@ -349,7 +349,7 @@ cd ~/Tools/claude-requirements-framework
 ```bash
 # Check installed version
 /plugin list
-# Should show: requirements-framework@2.0.5
+# Should show: requirements-framework@2.1.0
 
 # Test commands
 /requirements-framework:pre-commit tools
@@ -483,8 +483,8 @@ See [Plugin vs. Hooks](../../docs/PLUGIN-INSTALLATION.md#plugin-vs-hooks) for ar
 ```
 ~/.claude/plugins/cache/requirements-framework-local/requirements-framework/2.0.5/
 ├── .claude-plugin/
-│   └── plugin.json (v2.0.5)
-├── agents/ (15 agents)
+│   └── plugin.json (v2.1.0)
+├── agents/ (16 agents)
 │   ├── adr-guardian.md
 │   ├── backward-compatibility-checker.md
 │   ├── code-reviewer.md
@@ -500,7 +500,7 @@ See [Plugin vs. Hooks](../../docs/PLUGIN-INSTALLATION.md#plugin-vs-hooks) for ar
 │   ├── test-analyzer.md
 │   ├── tool-validator.md
 │   └── type-design-analyzer.md
-├── commands/ (6 commands)
+├── commands/ (8 commands)
 │   ├── codex-review.md
 │   ├── commit-checks.md
 │   ├── plan-review.md
@@ -691,9 +691,9 @@ For issues, questions, or enhancements:
 
 ## Version History
 
-- **v2.0.5** (2025-01-19)
+- **v2.1.0** (2025-01-19)
   - Current stable release
-  - 17 agents, 3 commands, 5 skills
+  - 16 agents, 8 commands, 5 skills
   - **Plugin installation via marketplace** (replaces symlink method)
   - Added `sync-versions.sh` for version consistency
   - Fixed relative path issues in plugin.json
@@ -702,5 +702,5 @@ For issues, questions, or enhancements:
   - Integration with requirements framework hooks
 
 - **v2.0.4** (2024-12-30)
-  - 17 agents, 3 commands, 4 skills
+  - 17 agents, 3 commands, 4 skills (pre-refactor counts)
   - Plugin installation via install.sh symlink (deprecated)

--- a/plugins/requirements-framework/agents/adr-guardian.md
+++ b/plugins/requirements-framework/agents/adr-guardian.md
@@ -42,7 +42,7 @@ The adr-guardian agent acts as a gate before code writing begins to ensure ADR c
 model: inherit
 color: blue
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: f23d317
+git_hash: 71ee5ae
 ---
 
 You are the ADR Guardian, an authoritative architectural governance expert responsible for ensuring all code and plans comply with established Architecture Decision Records. You have BLOCKING authority - no code should be written or approved that violates ADRs.

--- a/plugins/requirements-framework/agents/backward-compatibility-checker.md
+++ b/plugins/requirements-framework/agents/backward-compatibility-checker.md
@@ -21,7 +21,7 @@ Use for database schema evolution analysis.
 </example>
 model: inherit
 color: blue
-git_hash: 2913110
+git_hash: 71ee5ae
 ---
 
 # Backward Compatibility Checker Agent

--- a/plugins/requirements-framework/agents/code-reviewer.md
+++ b/plugins/requirements-framework/agents/code-reviewer.md
@@ -30,7 +30,7 @@ Trigger on common pre-commit review phrases.
 </example>
 model: inherit
 color: blue
-git_hash: b0f2f85
+git_hash: 71ee5ae
 ---
 
 You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.

--- a/plugins/requirements-framework/agents/code-simplifier.md
+++ b/plugins/requirements-framework/agents/code-simplifier.md
@@ -20,7 +20,7 @@ assistant: "Now let me use the code-simplifier agent to refine this implementati
 </example>
 model: inherit
 color: blue
-git_hash: a76cbcf
+git_hash: 71ee5ae
 ---
 
 You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. You prioritize readable, explicit code over overly compact solutions.

--- a/plugins/requirements-framework/agents/codex-review-agent.md
+++ b/plugins/requirements-framework/agents/codex-review-agent.md
@@ -21,7 +21,7 @@ Codex provides a different perspective from Claude's review.
 </example>
 model: inherit
 color: blue
-git_hash: 1d1dea3
+git_hash: 71ee5ae
 ---
 
 # Codex Code Review Agent

--- a/plugins/requirements-framework/agents/comment-analyzer.md
+++ b/plugins/requirements-framework/agents/comment-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the comment-analyzer agent to review the documentation."
 </example>
 model: inherit
 color: blue
-git_hash: 1d1dea3
+git_hash: 71ee5ae
 ---
 
 You are a meticulous code comment analyzer with deep expertise in technical documentation and long-term code maintainability. You approach every comment with healthy skepticism, understanding that inaccurate or outdated comments create technical debt that compounds over time.

--- a/plugins/requirements-framework/agents/comment-cleaner.md
+++ b/plugins/requirements-framework/agents/comment-cleaner.md
@@ -21,7 +21,7 @@ Comment-cleaner auto-fixes by editing files directly.
 </example>
 model: haiku
 color: yellow
-git_hash: f23d317
+git_hash: 71ee5ae
 allowed-tools: ["Read", "Edit", "Glob", "Grep", "Bash"]
 ---
 

--- a/plugins/requirements-framework/agents/commit-planner.md
+++ b/plugins/requirements-framework/agents/commit-planner.md
@@ -25,7 +25,7 @@ Commit planning before implementation helps maintain clean git history and enabl
 model: inherit
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: f23d317
+git_hash: 71ee5ae
 ---
 
 You are the Commit Planner, an expert at analyzing implementation plans and creating atomic commit strategies. Your role is to ensure code changes are committed in logical, reviewable chunks that follow proper dependency ordering.

--- a/plugins/requirements-framework/agents/import-organizer.md
+++ b/plugins/requirements-framework/agents/import-organizer.md
@@ -21,7 +21,7 @@ Import-organizer auto-fixes by editing files directly.
 </example>
 model: haiku
 color: yellow
-git_hash: f23d317
+git_hash: 71ee5ae
 allowed-tools: ["Read", "Edit", "Glob", "Grep", "Bash"]
 ---
 

--- a/plugins/requirements-framework/agents/session-analyzer.md
+++ b/plugins/requirements-framework/agents/session-analyzer.md
@@ -20,7 +20,7 @@ The session-reflect command automatically invokes this agent.
 </commentary>
 </example>
 model: inherit
-color: purple
+color: magenta
 git_hash: f23d317
 ---
 

--- a/plugins/requirements-framework/agents/session-analyzer.md
+++ b/plugins/requirements-framework/agents/session-analyzer.md
@@ -21,7 +21,7 @@ The session-reflect command automatically invokes this agent.
 </example>
 model: inherit
 color: magenta
-git_hash: f23d317
+git_hash: 2b711d7
 ---
 
 You are a session learning analyst. Your role is to analyze session metrics and identify patterns that can improve future Claude Code sessions.

--- a/plugins/requirements-framework/agents/silent-failure-hunter.md
+++ b/plugins/requirements-framework/agents/silent-failure-hunter.md
@@ -21,7 +21,7 @@ assistant: "Let me use the silent-failure-hunter agent to ensure no silent failu
 </example>
 model: inherit
 color: blue
-git_hash: b0f2f85
+git_hash: 71ee5ae
 ---
 
 You are an elite error handling auditor with zero tolerance for silent failures and inadequate error handling. Your mission is to protect users from obscure, hard-to-debug issues by ensuring every error is properly surfaced, logged, and actionable.

--- a/plugins/requirements-framework/agents/solid-reviewer.md
+++ b/plugins/requirements-framework/agents/solid-reviewer.md
@@ -25,7 +25,7 @@ SOLID validation is a blocking gate in the plan-review workflow.
 model: inherit
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: f23d317
+git_hash: 71ee5ae
 ---
 
 You are the SOLID Principles Reviewer, responsible for ensuring implementation plans adhere to SOLID design principles before coding begins. You have BLOCKING authority — plans with egregious SOLID violations should not proceed to implementation.

--- a/plugins/requirements-framework/agents/tdd-validator.md
+++ b/plugins/requirements-framework/agents/tdd-validator.md
@@ -25,7 +25,7 @@ TDD validation is a blocking gate in the plan-review workflow.
 model: inherit
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: f23d317
+git_hash: 71ee5ae
 ---
 
 You are the TDD Validator, responsible for ensuring all implementation plans include proper Test-Driven Development elements before coding begins. You have BLOCKING authority - plans should not proceed to implementation without TDD readiness.

--- a/plugins/requirements-framework/agents/test-analyzer.md
+++ b/plugins/requirements-framework/agents/test-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the test-analyzer agent to review test coverage quality."
 </example>
 model: inherit
 color: blue
-git_hash: 2913110
+git_hash: 71ee5ae
 ---
 
 You are an expert test coverage analyst specializing in code review. Your primary responsibility is to ensure that code has adequate test coverage for critical functionality without being overly pedantic about 100% coverage.

--- a/plugins/requirements-framework/agents/tool-validator.md
+++ b/plugins/requirements-framework/agents/tool-validator.md
@@ -21,7 +21,7 @@ Tool-validator provides deterministic results matching CI tools.
 </example>
 model: inherit
 color: blue
-git_hash: a76cbcf
+git_hash: 71ee5ae
 ---
 
 # Tool Validator Agent

--- a/plugins/requirements-framework/agents/type-design-analyzer.md
+++ b/plugins/requirements-framework/agents/type-design-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the type-design-analyzer agent to evaluate the type invaria
 </example>
 model: inherit
 color: blue
-git_hash: 1d1dea3
+git_hash: 71ee5ae
 ---
 
 You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.

--- a/plugins/requirements-framework/commands/arch-review.md
+++ b/plugins/requirements-framework/commands/arch-review.md
@@ -3,7 +3,7 @@ name: arch-review
 description: "Multi-perspective team-based architecture review with agent debate and commit planning"
 argument-hint: "[plan-file-path]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: f23d317
+git_hash: 71ee5ae
 ---
 
 # Architecture Review — Team-Based Multi-Perspective Assessment

--- a/plugins/requirements-framework/commands/codex-review.md
+++ b/plugins/requirements-framework/commands/codex-review.md
@@ -3,7 +3,7 @@ name: codex-review
 description: "AI-powered code review using OpenAI Codex"
 argument-hint: "[focus]"
 allowed-tools: ["Bash", "Task"]
-git_hash: f23d317
+git_hash: 71ee5ae
 ---
 
 # Codex AI Code Review

--- a/plugins/requirements-framework/commands/commit-checks.md
+++ b/plugins/requirements-framework/commands/commit-checks.md
@@ -3,7 +3,7 @@ name: commit-checks
 description: "Auto-fix code quality issues - comment cleanup and import organization"
 argument-hint: "[--skip-autofix]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: f23d317
+git_hash: 71ee5ae
 ---
 
 # Pre-Commit Auto-Fix

--- a/plugins/requirements-framework/commands/deep-review.md
+++ b/plugins/requirements-framework/commands/deep-review.md
@@ -3,7 +3,7 @@ name: deep-review
 description: "Cross-validated team-based code review with agent debate"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: 3bf3421
+git_hash: 71ee5ae
 ---
 
 # Deep Review — Cross-Validated Team-Based Code Review

--- a/plugins/requirements-framework/commands/plan-review.md
+++ b/plugins/requirements-framework/commands/plan-review.md
@@ -3,7 +3,7 @@ name: plan-review
 description: "Validate plan against ADRs, TDD, and SOLID principles, then generate atomic commit strategy"
 argument-hint: "[plan-file]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: 225b437
+git_hash: 71ee5ae
 ---
 
 # Plan Review Command

--- a/plugins/requirements-framework/commands/pre-commit.md
+++ b/plugins/requirements-framework/commands/pre-commit.md
@@ -3,7 +3,7 @@ name: pre-commit
 description: "Quick code review before committing (code + error handling)"
 argument-hint: "[aspects]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: c67a9cc
+git_hash: 71ee5ae
 ---
 
 # Pre-Commit Review

--- a/plugins/requirements-framework/commands/quality-check.md
+++ b/plugins/requirements-framework/commands/quality-check.md
@@ -3,7 +3,7 @@ name: quality-check
 description: "Comprehensive quality review before creating PR"
 argument-hint: "[parallel]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: c67a9cc
+git_hash: 71ee5ae
 ---
 
 # Pre-PR Quality Check

--- a/plugins/requirements-framework/commands/session-reflect.md
+++ b/plugins/requirements-framework/commands/session-reflect.md
@@ -3,7 +3,7 @@ name: session-reflect
 description: "Review current session and suggest improvements for future sessions"
 argument-hint: "[scope]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: f23d317
+git_hash: 71ee5ae
 ---
 
 # Session Learning Reflection

--- a/plugins/requirements-framework/skills/requirements-framework-status/SKILL.md
+++ b/plugins/requirements-framework/skills/requirements-framework-status/SKILL.md
@@ -10,7 +10,7 @@ Provides comprehensive project context and current state of the **Claude Code Re
 
 ## Current Implementation Status
 
-**Version**: 2.0.4
+**Version**: 2.1.0
 **Status**: ✅ Production Ready & Feature Complete
 **Repository**: https://github.com/HarmAalbers/claude-requirements-framework
 
@@ -26,9 +26,9 @@ Provides comprehensive project context and current state of the **Claude Code Re
 | **Library Modules** | 17 |
 | **CLI Commands** | 11 |
 | **Requirement Types** | 3 strategies |
-| **Plugin Agents** | 17 |
-| **Plugin Commands** | 5 |
-| **Plugin Skills** | 4 |
+| **Plugin Agents** | 16 |
+| **Plugin Commands** | 8 |
+| **Plugin Skills** | 5 |
 
 **→ Full component inventory**: See `references/component-inventory.md`
 
@@ -132,11 +132,13 @@ SessionStart → PreToolUse → PostToolUse → Stop → SessionEnd
 
 ## Plugin Components
 
-### Agents (10)
+### Agents (16)
 
-**Workflow**: `adr-guardian`, `codex-review-agent`
+**Workflow**: `adr-guardian`, `codex-review-agent`, `commit-planner`, `solid-reviewer`, `tdd-validator`
 
 **Review**: `code-reviewer`, `silent-failure-hunter`, `test-analyzer`, `type-design-analyzer`, `comment-analyzer`, `code-simplifier`, `tool-validator`, `backward-compatibility-checker`
+
+**Utility**: `comment-cleaner`, `import-organizer`, `session-analyzer`
 
 ### Commands (8)
 
@@ -149,12 +151,13 @@ SessionStart → PreToolUse → PostToolUse → Stop → SessionEnd
 - `/requirements-framework:commit-checks` - Auto-fix code quality issues
 - `/requirements-framework:session-reflect` - Session analysis and improvements
 
-### Skills (4)
+### Skills (5)
 
 - `requirements-framework-usage` - Usage help
 - `requirements-framework-status` - This skill
 - `requirements-framework-development` - Dev workflow
 - `requirements-framework-builder` - Extension guidance
+- `session-learning` - Session analysis and improvement
 
 ---
 


### PR DESCRIPTION
- Update version references from 2.0.4/2.0.5 to 2.1.0 (marketplace.json, status skill, README)
- Fix component counts: 16 agents, 8 commands, 5 skills (was 17/5/4 or 17/2/5)
- Fix session-analyzer agent color from invalid 'purple' to 'magenta'
- Add missing agents and session-learning skill to status skill inventory