### PR TITLE
feat: bring 5 deployed-only hooks and plugin registration into repo

### DIFF
--- a/hooks/handle-permission-request.py
+++ b/hooks/handle-permission-request.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+PermissionRequest Hook for Requirements Framework.
+
+Triggered when a permission dialog is about to be shown.
+Responsibilities:
+1. Auto-deny dangerous command patterns (rm -rf, force push, etc.)
+2. Log permission patterns in session metrics
+
+Input (stdin JSON):
+{
+    "session_id": "abc123",
+    "hook_event_name": "PermissionRequest",
+    "tool_name": "Bash",
+    "tool_input": {"command": "rm -rf /"},
+    "cwd": "/path/to/project"
+}
+
+Output:
+- {"decision": "deny", "reason": "..."} to block dangerous commands
+- Empty to allow the permission dialog to proceed normally
+"""
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Add lib to path
+lib_path = Path(__file__).parent / 'lib'
+sys.path.insert(0, str(lib_path))
+
+from session import normalize_session_id
+from session_metrics import SessionMetrics
+from hook_utils import early_hook_setup
+from console import emit_json
+
+# Dangerous command patterns that should be auto-denied
+DANGEROUS_PATTERNS = [
+    (re.compile(r'rm\s+(-[rfR]+\s+)?/(?!\btmp\b)'), 'Destructive rm on root directory'),
+    (re.compile(r'git\s+push\s+.*--force(?!-with-lease)'), 'Force push without lease protection'),
+    (re.compile(r'git\s+push\s+.*-f\b'), 'Force push (shorthand)'),
+    (re.compile(r'git\s+reset\s+--hard\s+origin/(?:main|master)'), 'Hard reset to remote main'),
+    (re.compile(r'git\s+clean\s+-[dfx]+'), 'Git clean (removes untracked files)'),
+    (re.compile(r'DROP\s+(?:TABLE|DATABASE)', re.IGNORECASE), 'SQL DROP statement'),
+    (re.compile(r'TRUNCATE\s+TABLE', re.IGNORECASE), 'SQL TRUNCATE statement'),
+]
+
+
+def main() -> int:
+    """Hook entry point."""
+    input_data = {}
+    try:
+        stdin_content = sys.stdin.read()
+        if stdin_content:
+            input_data = json.loads(stdin_content)
+    except json.JSONDecodeError:
+        return 0  # Fail open
+
+    raw_session = input_data.get('session_id')
+    if not raw_session:
+        return 0
+
+    session_id = normalize_session_id(raw_session)
+    tool_name = input_data.get('tool_name', '')
+    tool_input = input_data.get('tool_input', {})
+
+    # Early hook setup
+    project_dir, branch, config, logger = early_hook_setup(
+        session_id, "PermissionRequest", cwd=input_data.get('cwd')
+    )
+
+    try:
+        if os.environ.get('CLAUDE_SKIP_REQUIREMENTS'):
+            return 0
+
+        if not project_dir or not branch or not config:
+            return 0
+
+        if not config.is_enabled():
+            return 0
+
+        # Check if permission safety is enabled (default: True)
+        if not config.get_hook_config('permission_request', 'auto_deny_dangerous', True):
+            return 0
+
+        # Only check Bash commands for dangerous patterns
+        if tool_name != 'Bash':
+            return 0
+
+        command = tool_input.get('command', '')
+        if not command:
+            return 0
+
+        # Check against dangerous patterns
+        for pattern, description in DANGEROUS_PATTERNS:
+            if pattern.search(command):
+                logger.warning(
+                    "Auto-denied dangerous command",
+                    command_preview=command[:100],
+                    reason=description,
+                )
+
+                # Record in metrics
+                try:
+                    metrics = SessionMetrics(session_id, project_dir, branch)
+                    metrics.record_tool_use('PermissionDenied', blocked=True)
+                    metrics.save()
+                except Exception:
+                    pass
+
+                response = {
+                    "decision": "deny",
+                    "reason": f"**Blocked by requirements framework**: {description}\n\n"
+                              f"Command: `{command[:80]}{'...' if len(command) > 80 else ''}`\n\n"
+                              "If you need to run this command, disable the safety check:\n"
+                              "`req config set hooks.permission_request.auto_deny_dangerous false`"
+                }
+                emit_json(response)
+                return 0
+
+        return 0
+
+    except Exception as e:
+        logger.error("Unhandled error in PermissionRequest hook", error=str(e))
+        return 0  # Fail open
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/hooks/handle-pre-compact.py
+++ b/hooks/handle-pre-compact.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+PreCompact Hook for Requirements Framework.
+
+Triggered before context compaction (auto or manual).
+Responsibilities:
+1. Save requirement state and session metrics before compaction
+2. Track compaction frequency in session metrics
+
+Input (stdin JSON):
+{
+    "session_id": "abc123",
+    "hook_event_name": "PreCompact",
+    "source": "manual|auto",
+    "cwd": "/path/to/project"
+}
+
+Output:
+- Empty (metrics recording only)
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add lib to path
+lib_path = Path(__file__).parent / 'lib'
+sys.path.insert(0, str(lib_path))
+
+from session import normalize_session_id
+from session_metrics import SessionMetrics
+from hook_utils import early_hook_setup
+
+
+def main() -> int:
+    """Hook entry point."""
+    input_data = {}
+    try:
+        stdin_content = sys.stdin.read()
+        if stdin_content:
+            input_data = json.loads(stdin_content)
+    except json.JSONDecodeError:
+        return 0  # Fail open
+
+    raw_session = input_data.get('session_id')
+    if not raw_session:
+        return 0
+
+    session_id = normalize_session_id(raw_session)
+    source = input_data.get('source', 'unknown')
+
+    # Early hook setup
+    project_dir, branch, config, logger = early_hook_setup(
+        session_id, "PreCompact", cwd=input_data.get('cwd')
+    )
+
+    try:
+        if os.environ.get('CLAUDE_SKIP_REQUIREMENTS'):
+            return 0
+
+        if not project_dir or not branch or not config:
+            return 0
+
+        if not config.is_enabled():
+            return 0
+
+        # Record compaction event in session metrics
+        metrics = SessionMetrics(session_id, project_dir, branch)
+        metrics.record_tool_use(f'Compact:{source}', blocked=False)
+
+        # Track compaction count
+        try:
+            compaction_count = metrics.data.get('compaction_count', 0) + 1
+            metrics.data['compaction_count'] = compaction_count
+            metrics.save()
+            logger.info(
+                "Pre-compaction state saved",
+                source=source,
+                compaction_count=compaction_count,
+            )
+        except Exception as e:
+            logger.debug("Failed to save compaction metrics", error=str(e))
+
+        return 0
+
+    except Exception as e:
+        logger.error("Unhandled error in PreCompact hook", error=str(e))
+        return 0  # Fail open
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/hooks/handle-prompt-submit.py
+++ b/hooks/handle-prompt-submit.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit Hook for Requirements Framework.
+
+Triggered when the user submits a prompt, BEFORE Claude processes it.
+Responsibilities:
+1. Inject compact requirement status when prompt relates to editing/committing
+2. Track prompt count in session metrics
+
+Input (stdin JSON):
+{
+    "session_id": "abc123",
+    "hook_event_name": "UserPromptSubmit",
+    "prompt": "The user's full prompt text",
+    "cwd": "/path/to/project"
+}
+
+Output:
+- Structured JSON with hookSpecificOutput.additionalContext (injected into Claude's context)
+- Empty if no context needed
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add lib to path
+lib_path = Path(__file__).parent / 'lib'
+sys.path.insert(0, str(lib_path))
+
+from requirements import BranchRequirements
+from session import normalize_session_id
+from session_metrics import SessionMetrics
+from hook_utils import early_hook_setup
+from console import emit_hook_context
+
+# Keywords that suggest the user is about to edit/commit/deploy
+EDIT_KEYWORDS = {
+    'edit', 'write', 'modify', 'change', 'update', 'fix', 'add', 'remove',
+    'delete', 'refactor', 'implement', 'create', 'build',
+}
+COMMIT_KEYWORDS = {
+    'commit', 'push', 'deploy', 'release', 'merge', 'pr ', 'pull request',
+    'git add', 'git commit', 'git push', 'gh pr',
+}
+
+
+def _prompt_needs_context(prompt: str) -> bool:
+    """Check if a prompt relates to editing or committing."""
+    prompt_lower = prompt.lower()
+    # Check commit keywords (higher priority)
+    for keyword in COMMIT_KEYWORDS:
+        if keyword in prompt_lower:
+            return True
+    # Check edit keywords
+    words = set(prompt_lower.split())
+    return bool(words & EDIT_KEYWORDS)
+
+
+def main() -> int:
+    """Hook entry point."""
+    input_data = {}
+    try:
+        stdin_content = sys.stdin.read()
+        if stdin_content:
+            input_data = json.loads(stdin_content)
+    except json.JSONDecodeError:
+        return 0  # Fail open
+
+    # Get session ID
+    raw_session = input_data.get('session_id')
+    if not raw_session:
+        return 0  # Fail open
+
+    session_id = normalize_session_id(raw_session)
+    prompt = input_data.get('prompt', '')
+
+    # Early hook setup
+    project_dir, branch, config, logger = early_hook_setup(
+        session_id, "UserPromptSubmit", cwd=input_data.get('cwd')
+    )
+
+    try:
+        if os.environ.get('CLAUDE_SKIP_REQUIREMENTS'):
+            return 0
+
+        if not project_dir or not branch or not config:
+            return 0
+
+        if not config.is_enabled():
+            return 0
+
+        # Track prompt in session metrics
+        try:
+            metrics = SessionMetrics(session_id, project_dir, branch)
+            metrics.record_tool_use('UserPrompt', blocked=False)
+            metrics.save()
+        except Exception as e:
+            logger.debug("Failed to record prompt metric", error=str(e))
+
+        # Only inject context when prompt relates to editing/committing
+        if not prompt or not _prompt_needs_context(prompt):
+            return 0
+
+        # Build compact status
+        reqs = BranchRequirements(branch, session_id, project_dir)
+        unsatisfied = []
+        for req_name in config.get_all_requirements():
+            if not config.is_requirement_enabled(req_name):
+                continue
+            scope = config.get_scope(req_name)
+            if not reqs.is_satisfied(req_name, scope):
+                unsatisfied.append(req_name)
+
+        if not unsatisfied:
+            return 0  # All satisfied, no context needed
+
+        # Inject compact reminder
+        context = f"**Requirements reminder**: {len(unsatisfied)} unsatisfied: {', '.join(unsatisfied)}"
+        emit_hook_context("UserPromptSubmit", context)
+        logger.debug("Injected prompt context", unsatisfied_count=len(unsatisfied))
+
+        return 0
+
+    except Exception as e:
+        logger.error("Unhandled error in UserPromptSubmit hook", error=str(e))
+        return 0  # Fail open
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/hooks/handle-subagent-start.py
+++ b/hooks/handle-subagent-start.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+SubagentStart Hook for Requirements Framework.
+
+Triggered when a subagent (Task tool) is spawned.
+Injects requirement context into review subagents so they are aware
+of the current requirement state and can focus their review accordingly.
+
+Input (stdin JSON):
+{
+    "session_id": "abc123",
+    "hook_event_name": "SubagentStart",
+    "agent_name": "code-reviewer",
+    "agent_type": "requirements-framework:code-reviewer",
+    "cwd": "/path/to/project"
+}
+
+Output:
+- Structured JSON with hookSpecificOutput.additionalContext
+- Empty if agent is not a review agent
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add lib to path
+lib_path = Path(__file__).parent / 'lib'
+sys.path.insert(0, str(lib_path))
+
+from requirements import BranchRequirements
+from session import normalize_session_id
+from session_metrics import SessionMetrics
+from hook_utils import early_hook_setup
+from console import emit_hook_context
+
+# Review agent types that benefit from requirement context injection
+REVIEW_AGENTS = {
+    'requirements-framework:code-reviewer',
+    'requirements-framework:silent-failure-hunter',
+    'requirements-framework:tool-validator',
+    'requirements-framework:test-analyzer',
+    'requirements-framework:type-design-analyzer',
+    'requirements-framework:comment-analyzer',
+    'requirements-framework:code-simplifier',
+    'requirements-framework:backward-compatibility-checker',
+    'requirements-framework:adr-guardian',
+    'requirements-framework:codex-review-agent',
+    'requirements-framework:solid-reviewer',
+    'requirements-framework:commit-planner',
+}
+
+
+def main() -> int:
+    """Hook entry point."""
+    input_data = {}
+    try:
+        stdin_content = sys.stdin.read()
+        if stdin_content:
+            input_data = json.loads(stdin_content)
+    except json.JSONDecodeError:
+        return 0  # Fail open
+
+    raw_session = input_data.get('session_id')
+    if not raw_session:
+        return 0
+
+    session_id = normalize_session_id(raw_session)
+    agent_type = input_data.get('agent_type', '')
+
+    # Early hook setup
+    project_dir, branch, config, logger = early_hook_setup(
+        session_id, "SubagentStart", cwd=input_data.get('cwd')
+    )
+
+    try:
+        if os.environ.get('CLAUDE_SKIP_REQUIREMENTS'):
+            return 0
+
+        if not project_dir or not branch or not config:
+            return 0
+
+        if not config.is_enabled():
+            return 0
+
+        # Track subagent spawn in session metrics
+        try:
+            metrics = SessionMetrics(session_id, project_dir, branch)
+            metrics.record_tool_use(f'SubagentStart:{agent_type}', blocked=False)
+            metrics.save()
+        except Exception as e:
+            logger.debug("Failed to record subagent metric", error=str(e))
+
+        # Only inject context into review agents
+        if agent_type not in REVIEW_AGENTS:
+            return 0
+
+        # Build requirement context for review agents
+        reqs = BranchRequirements(branch, session_id, project_dir)
+        unsatisfied = []
+        for req_name in config.get_all_requirements():
+            if not config.is_requirement_enabled(req_name):
+                continue
+            scope = config.get_scope(req_name)
+            if not reqs.is_satisfied(req_name, scope):
+                unsatisfied.append(req_name)
+
+        lines = [
+            "## Requirements Framework Context",
+            "",
+            f"**Branch**: `{branch}` | **Project**: `{project_dir}`",
+        ]
+
+        if unsatisfied:
+            lines.append(f"**Unsatisfied requirements**: {', '.join(unsatisfied)}")
+            lines.append("")
+            lines.append("Focus your review on issues that relate to these requirements.")
+        else:
+            lines.append("**All requirements satisfied.**")
+
+        emit_hook_context("SubagentStart", "\n".join(lines))
+        logger.debug("Injected context into review agent", agent_type=agent_type)
+
+        return 0
+
+    except Exception as e:
+        logger.error("Unhandled error in SubagentStart hook", error=str(e))
+        return 0  # Fail open
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/hooks/handle-tool-failure.py
+++ b/hooks/handle-tool-failure.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+PostToolUseFailure Hook for Requirements Framework.
+
+Triggered when a tool call fails (throws error or returns failure).
+Responsibilities:
+1. Track failure patterns in session metrics
+2. Provide requirement-aware error guidance
+3. Suggest running review skills after repeated failures
+
+Input (stdin JSON):
+{
+    "session_id": "abc123",
+    "hook_event_name": "PostToolUseFailure",
+    "tool_name": "Edit",
+    "tool_input": {"file_path": "/path/to/file"},
+    "error": "Error message string",
+    "is_interrupt": false,
+    "cwd": "/path/to/project"
+}
+
+Output:
+- Structured JSON with hookSpecificOutput.additionalContext (guidance)
+- Empty if no guidance needed
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add lib to path
+lib_path = Path(__file__).parent / 'lib'
+sys.path.insert(0, str(lib_path))
+
+from session import normalize_session_id
+from session_metrics import SessionMetrics
+from hook_utils import early_hook_setup
+from console import emit_hook_context
+
+# Failure threshold before suggesting review
+FAILURE_THRESHOLD = 3
+
+
+def main() -> int:
+    """Hook entry point."""
+    input_data = {}
+    try:
+        stdin_content = sys.stdin.read()
+        if stdin_content:
+            input_data = json.loads(stdin_content)
+    except json.JSONDecodeError:
+        return 0  # Fail open
+
+    raw_session = input_data.get('session_id')
+    if not raw_session:
+        return 0
+
+    session_id = normalize_session_id(raw_session)
+    tool_name = input_data.get('tool_name', '')
+    error_msg = input_data.get('error', '')
+    is_interrupt = input_data.get('is_interrupt', False)
+
+    # Early hook setup
+    project_dir, branch, config, logger = early_hook_setup(
+        session_id, "PostToolUseFailure", cwd=input_data.get('cwd')
+    )
+
+    try:
+        if os.environ.get('CLAUDE_SKIP_REQUIREMENTS'):
+            return 0
+
+        if not project_dir or not branch or not config:
+            return 0
+
+        if not config.is_enabled():
+            return 0
+
+        # Don't process interrupts
+        if is_interrupt:
+            return 0
+
+        # Record failure in session metrics
+        metrics = SessionMetrics(session_id, project_dir, branch)
+        metrics.record_tool_use(tool_name, blocked=False, file=None)
+
+        # Track failure count for this tool type
+        summary = metrics.get_summary()
+        # Use a simple counter based on existing metrics
+        failure_key = f'failures_{tool_name}'
+        failures = summary.get(failure_key, 0) + 1
+
+        # Store updated failure count
+        try:
+            metrics.data.setdefault('failure_counts', {})[tool_name] = failures
+            metrics.save()
+        except Exception as e:
+            logger.debug("Failed to save failure count", error=str(e))
+
+        logger.info(
+            "Tool failure recorded",
+            tool=tool_name,
+            error_preview=error_msg[:100] if error_msg else "",
+            failure_count=failures,
+        )
+
+        # After repeated Edit/Write failures, suggest running pre-commit review
+        if tool_name in ('Edit', 'Write', 'MultiEdit') and failures >= FAILURE_THRESHOLD:
+            context = (
+                f"**Repeated {tool_name} failures detected** ({failures} failures). "
+                "Consider running `/pre-commit` to identify underlying issues before continuing."
+            )
+            emit_hook_context("PostToolUseFailure", context)
+
+        return 0
+
+    except Exception as e:
+        logger.error("Unhandled error in PostToolUseFailure hook", error=str(e))
+        return 0  # Fail open
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/plugins/requirements-framework/hooks/hooks.json
+++ b/plugins/requirements-framework/hooks/hooks.json
@@ -1,0 +1,175 @@
+{
+  "description": "Requirements Framework - Enforces project requirements and quality gates through Claude Code hooks",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|Bash|EnterPlanMode|ExitPlanMode|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/check-requirements.py",
+            "statusMessage": "Checking requirements..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/auto-satisfy-skills.py",
+            "statusMessage": "Processing skill completion..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/clear-single-use.py",
+            "statusMessage": "Updating requirement state..."
+          }
+        ]
+      },
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-plan-exit.py",
+            "statusMessage": "Validating plan requirements..."
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-session-start.py",
+            "statusMessage": "Initializing requirements framework..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-stop.py",
+            "statusMessage": "Verifying requirements..."
+          },
+          {
+            "type": "prompt",
+            "prompt": "Review the conversation. The user has a requirements framework that tracks development workflow requirements. Check if the user's original task appears complete. If the conversation shows unfinished work, unsatisfied requirements mentioned in system reminders, or pending TODO items, respond with ok: false and explain what remains. If work appears complete, respond with ok: true. Context: $ARGUMENTS",
+            "model": "haiku",
+            "statusMessage": "Evaluating task completion..."
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-session-end.py",
+            "statusMessage": "Cleaning up session..."
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-teammate-idle.py",
+            "statusMessage": "Processing teammate idle event..."
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-task-completed.py",
+            "statusMessage": "Validating task completion..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-prompt-submit.py",
+            "statusMessage": "Checking requirement context..."
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-subagent-start.py",
+            "statusMessage": "Injecting review context..."
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-tool-failure.py",
+            "statusMessage": "Recording failure metrics..."
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-pre-compact.py",
+            "statusMessage": "Saving requirement state..."
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-permission-request.py",
+            "statusMessage": "Checking command safety..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Bring 5 hook scripts from deployed location (`~/.claude/hooks/`) into the repository so `sync.sh` can manage them properly
- Add `hooks.json` plugin registration file covering all 13 hook event handlers
- Update CLAUDE.md session lifecycle documentation from 8 to 13 hooks

### New hooks added:
- **handle-permission-request.py** — auto-denies dangerous commands (rm -rf, force push, etc.)
- **handle-tool-failure.py** — tracks tool failure patterns, suggests review after threshold
- **handle-pre-compact.py** — saves session metrics before context compaction
- **handle-prompt-submit.py** — injects requirement status reminders into edit/commit prompts
- **handle-subagent-start.py** — injects requirement context into review subagents

### Plugin registration:
- **hooks.json** — registers all 12 hook event types (13 handlers, PostToolUse has 3 matchers)

## Known Issues (pre-existing in production)

These bugs exist in the currently deployed hooks and are documented for follow-up:

1. `metrics.data` AttributeError — `SessionMetrics` has no `.data` attribute (internal is `._metrics`). Affects compaction tracking in handle-pre-compact.py and failure counting in handle-tool-failure.py. Both fail-open safely via try/except.
2. `get_summary()` disconnect — handle-tool-failure.py reads failure counts from `get_summary()` which never returns `failures_*` keys. The repeated-failure suggestion feature is dead code.
3. No test coverage — all 5 hooks lack dedicated tests (shared utilities are tested).

## Test plan

- [x] `./sync.sh status` — all files show "In sync", no "Missing in repository" entries
- [x] `python3 hooks/test_requirements.py` — 976/976 tests pass
- [x] Smoke tests — all 5 hooks exit 0 with empty stdin (fail-open)
- [x] `hooks.json` validates as JSON with all 12 event types
- [ ] Follow-up: add unit tests for the 5 new hooks (separate PR)
- [ ] Follow-up: fix `metrics.data` bug in handle-pre-compact.py and handle-tool-failure.py (separate PR)