### PR TITLE
feat: add data-cy obsolescence check to frontend-reviewer

### DIFF
--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Claude Code Requirements Framework - Enforces development workflow requirements (commit planning, ADR review, TDD) through hooks. Features customizable checklists, session management, and comprehensive code review agents.",
   "author": {
     "name": "Harm"

--- a/plugins/requirements-framework/agents/frontend-reviewer.md
+++ b/plugins/requirements-framework/agents/frontend-reviewer.md
@@ -130,6 +130,10 @@ Review ALL changed frontend files against these categories. Only report findings
 24. **Error boundaries**: Complex component subtrees (data fetching, third-party integrations, dynamic content) should be wrapped in Error Boundaries
 25. **No unsafe HTML injection**: `dangerouslySetInnerHTML` must not be used without sanitization (DOMPurify or equivalent). If found without sanitization, always flag as CRITICAL.
 
+### Testing
+
+26. **No obsolete data-cy attributes**: `data-cy` is a deprecated Cypress-specific test selector. Use `data-testid` instead, which is the modern framework-agnostic standard supported by Testing Library, Playwright, and others. Flag any new or modified `data-cy` attributes.
+
 ## Step 4: Apply Project Checklist
 
 If a project-specific checklist was found in Step 2:
@@ -204,6 +208,6 @@ If no findings: set all counts to 0 and verdict to APPROVED.
 - **Be precise**: Only report findings you are confident about
 - **Be React-specific**: Cite specific React patterns, hooks rules, or a11y standards (WCAG)
 - **Be actionable**: Provide concrete fix suggestions with React-idiomatic code
-- **Be thorough**: Check all 25 built-in items plus any project checklist items
+- **Be thorough**: Check all 26 built-in items plus any project checklist items
 - **Filter aggressively**: Quality over quantity — false positives harm credibility
 - **Scope strictly**: Only review frontend files identified in Step 1 — ignore backend code


### PR DESCRIPTION
## Summary
- Adds check #26 to the frontend-reviewer agent: **No obsolete data-cy attributes**
- New **Testing** category in the built-in checks (alongside Hooks, Performance, a11y, etc.)
- Flags `data-cy` as deprecated and recommends `data-testid` as the modern framework-agnostic replacement (Testing Library, Playwright, Cypress)
- Severity: IMPORTANT (consistent with other anti-pattern checks)
- Plugin version bumped from 2.2.0 to 2.3.0

## Test plan
- [ ] Launch Claude Code with `--plugin-dir ~/Tools/claude-requirements-framework/plugin` 
- [ ] Create a test `.tsx` file with `data-cy="some-value"` attributes
- [ ] Run `/requirements-framework:pre-commit frontend` and verify the check flags `data-cy` usage
- [ ] Verify it suggests `data-testid` as replacement
- [ ] Confirm check count shows 26 built-in items in the Critical Rules section