### PR TITLE
Deprecate pre_commit_review requirement

### DIFF
--- a/.claude/requirements.yaml
+++ b/.claude/requirements.yaml
@@ -150,8 +150,13 @@ requirements:
       3. Override: `req approve single_session_per_project`
     checklist:
       - "Confirmed no other active sessions on this project"
+  # DEPRECATED: pre_commit_review is deprecated since v2.6.
+  # The /pre-commit command remains available for voluntary use.
+  # Use /deep-review or /arch-review for enforced review workflows instead.
   pre_commit_review:
-    enabled: true
+    enabled: false
+    deprecated: true
+    deprecated_message: "pre_commit_review is deprecated. Use /pre-commit voluntarily or /deep-review for enforced pre-PR review."
     type: blocking
     scope: single_use
     description: "Code review before each commit - resets after commit completes."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ PermissionRequest (handle-permission-request.py) - before permission dialog show
 
 PostToolUse (auto-satisfy-skills.py) - after Skill tool completes
     → Auto-satisfy requirements when review skills complete
-    → Maps: /requirements-framework:pre-commit → pre_commit_review
+    → Maps: /requirements-framework:pre-commit → pre_commit_review (deprecated, kept for backward compat)
     → Maps: /requirements-framework:quality-check → pre_pr_review
     → Maps: /requirements-framework:codex-review → codex_reviewer
     → Maps: /requirements-framework:plan-review → commit_plan, adr_reviewed, tdd_planned, solid_reviewed
@@ -63,7 +63,7 @@ PostToolUse (auto-satisfy-skills.py) - after Skill tool completes
 
 PostToolUse (clear-single-use.py) - after certain Bash commands
     → Clears single_use requirements after trigger commands
-    → Example: Clears pre_commit_review after git commit
+    → Example: Clears single_use requirements after trigger commands
 
 PostToolUse (handle-plan-exit.py) - after ExitPlanMode
     → Shows requirements status proactively

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Choose from context-aware presets optimized for your setup:
 - **`advanced`** - All features (recommended for global config)
   - 7 requirements showcasing every capability
   - Dynamic checks (branch_size_limit with calculator)
-  - Single-use requirements (pre_commit_review, pre_pr_review)
+  - Single-use requirements (pre_pr_review, codex_reviewer)
   - Guard requirements (protected_branch)
   - Perfect for discovering what the framework can do
 
@@ -122,7 +122,7 @@ Choose from context-aware presets optimized for your setup:
 
 **2. Custom Selection**
 Interactive checkbox to pick specific features:
-- Choose from: commit_plan, adr_reviewed, protected_branch, branch_size_limit, pre_commit_review, pre_pr_review
+- Choose from: commit_plan, adr_reviewed, protected_branch, branch_size_limit, pre_pr_review, codex_reviewer
 - Perfect for power users who know exactly what they want
 
 **3. Manual Setup**
@@ -309,26 +309,20 @@ requirements:
     approval_ttl: 3600  # 1 hour approval via `req approve`
 ```
 
-### pre_commit_review (Single-Use Scope)
+### pre_commit_review (Deprecated)
 
-Requires code review before every commit.
+> **Deprecated since v2.6.** The `/pre-commit` command remains available for voluntary use.
+> Use `/deep-review` or `/arch-review` for enforced review workflows instead.
 
-**Scope**: single_use - Must re-satisfy before EACH commit
+Previously required code review before every commit. Now disabled by default.
 
 ```yaml
 requirements:
+  # DEPRECATED: Use /pre-commit voluntarily instead.
   pre_commit_review:
-    enabled: true
-    type: blocking
-    scope: single_use
-    trigger_tools:
-      - tool: Bash
-        command_pattern: "git\\s+(commit|cherry-pick|revert|merge)"
-    message: |
-      Run `/requirements-framework:pre-commit` to review your code
+    enabled: false
+    deprecated: true
 ```
-
-**Auto-satisfied** when you run `/requirements-framework:pre-commit`
 
 ### pre_pr_review (Single-Use Scope)
 
@@ -440,7 +434,7 @@ The requirements framework includes a comprehensive plugin with specialized agen
 Fast pre-commit review with smart agent selection:
 - **Default** (no args): tool-validator + code-reviewer + silent-failure-hunter
 - **Arguments**: `tools`, `code`, `errors`, `compat`, `tests`, `types`, `comments`, `simplify`, `all`, `parallel`
-- **Integrated with**: `pre_commit_review` requirement (auto-satisfies on completion)
+- **Integrated with**: `pre_commit_review` requirement (auto-satisfies on completion, requirement deprecated)
 - **Execution**: Deterministic workflow with blocking gates (tool errors stop AI review)
 
 Examples:

--- a/docs/PLUGIN-INSTALLATION.md
+++ b/docs/PLUGIN-INSTALLATION.md
@@ -456,7 +456,7 @@ The Requirements Framework has two complementary components:
 
 | Plugin Command | Satisfies Requirement |
 |----------------|----------------------|
-| `/requirements-framework:pre-commit` | `pre_commit_review` |
+| `/requirements-framework:pre-commit` | `pre_commit_review` (deprecated) |
 | `/requirements-framework:quality-check` | `pre_pr_review` |
 
 **See:** `~/.claude/hooks/auto-satisfy-skills.py` for mapping logic
@@ -562,10 +562,8 @@ To use plugin commands as requirement satisfaction mechanisms:
 **~/.claude/requirements.yaml:**
 ```yaml
 requirements:
-  pre_commit_review:
-    scope: single_use
-    message: "Run /requirements-framework:pre-commit before committing"
-
+  # NOTE: pre_commit_review is deprecated since v2.6.
+  # Use /pre-commit voluntarily or /deep-review for enforced review.
   pre_pr_review:
     scope: single_use
     message: "Run /requirements-framework:quality-check before creating PR"

--- a/docs/README-REQUIREMENTS-FRAMEWORK.md
+++ b/docs/README-REQUIREMENTS-FRAMEWORK.md
@@ -493,7 +493,7 @@ requirements:
 4. Trigger action (e.g., `gh pr create`) is now allowed
 
 **Built-in Mappings** (for framework skills):
-- `requirements-framework:pre-commit` → `pre_commit_review`
+- `requirements-framework:pre-commit` → `pre_commit_review` (deprecated since v2.6)
 - `requirements-framework:quality-check` → `pre_pr_review`
 - `requirements-framework:codex-review` → `codex_reviewer`
 

--- a/docs/req-init-examples.md
+++ b/docs/req-init-examples.md
@@ -55,8 +55,8 @@ requirements:
       block: 400
     ...
   pre_commit_review:
-    enabled: true
-    scope: single_use
+    enabled: false  # Deprecated since v2.6
+    deprecated: true
     ...
   pre_pr_review:
     enabled: true
@@ -434,7 +434,7 @@ The `advanced` preset is designed to be an **educational tool**. When you run it
 1. **Blocking requirements** (commit_plan, adr_reviewed)
 2. **Guard requirements** (protected_branch) - prevents operations
 3. **Dynamic requirements** (branch_size_limit) - auto-calculated with thresholds
-4. **Single-use requirements** (pre_commit_review, pre_pr_review) - re-satisfy each time
+4. **Single-use requirements** (pre_pr_review, codex_reviewer) - re-satisfy each time
 5. **Branch-scoped requirements** (github_ticket, disabled) - once per branch
 6. **Tool-specific triggers** with command patterns (git commit, gh pr create)
 7. **Hooks configuration** (stop hook verification)

--- a/examples/global-requirements.yaml
+++ b/examples/global-requirements.yaml
@@ -224,10 +224,13 @@ requirements:
       ---
       Override: `req approve branch_size_limit`
 
-  # Pre-Commit Review Requirement
-  # Ensures code is reviewed before every commit
+  # DEPRECATED: pre_commit_review is deprecated since v2.6.
+  # The /pre-commit command remains available for voluntary use.
+  # Use /deep-review or /arch-review for enforced review workflows instead.
   pre_commit_review:
-    enabled: true
+    enabled: false
+    deprecated: true
+    deprecated_message: "pre_commit_review is deprecated. Use /pre-commit voluntarily or /deep-review for enforced pre-PR review."
     type: blocking
     scope: single_use  # Must re-satisfy before EACH commit
     description: "Code review before each commit - resets after commit completes."

--- a/hooks/lib/feature_catalog.py
+++ b/hooks/lib/feature_catalog.py
@@ -157,12 +157,17 @@ FEATURE_CATALOG: Dict[str, Dict[str, Any]] = {
         "name": "Pre-Commit Review",
         "category": CATEGORY_REQUIREMENTS,
         "config_path": "requirements.pre_commit_review",
-        "description": "Code review before each commit",
+        "description": "Code review before each commit (deprecated - use /pre-commit voluntarily)",
         "introduced": "1.0",
-        "default_enabled": True,
+        "deprecated": True,
+        "deprecated_message": "Deprecated since v2.6. Use /pre-commit voluntarily or /deep-review for enforced pre-PR review.",
+        "default_enabled": False,
         "example_yaml": """requirements:
+  # DEPRECATED: Use /pre-commit voluntarily instead.
   pre_commit_review:
-    enabled: true
+    enabled: false
+    deprecated: true
+    deprecated_message: "pre_commit_review is deprecated. Use /pre-commit voluntarily or /deep-review for enforced pre-PR review."
     type: blocking
     scope: single_use
     description: "Code review before each commit."

--- a/hooks/lib/feature_selector.py
+++ b/hooks/lib/feature_selector.py
@@ -44,11 +44,12 @@ FEATURES = {
         'type': 'dynamic',
     },
     'pre_commit_review': {
-        'name': 'Pre-Commit Review',
-        'description': 'Review before every commit',
+        'name': 'Pre-Commit Review (deprecated)',
+        'description': 'Review before every commit (use /pre-commit voluntarily instead)',
         'category': 'code_quality',
         'type': 'blocking',
         'scope': 'single_use',
+        'deprecated': True,
     },
     'pre_pr_review': {
         'name': 'Pre-PR Review',
@@ -86,8 +87,8 @@ class FeatureSelector:
             options.append(option_str)
             option_to_key[option_str] = key
 
-        # Default selections: commit_plan, adr_reviewed, pre_commit_review
-        default_keys = ['commit_plan', 'adr_reviewed', 'pre_commit_review']
+        # Default selections: commit_plan, adr_reviewed
+        default_keys = ['commit_plan', 'adr_reviewed']
         defaults = [
             f"{FEATURES[k]['name']} - {FEATURES[k]['description']}"
             for k in default_keys

--- a/hooks/lib/init_presets.py
+++ b/hooks/lib/init_presets.py
@@ -211,8 +211,12 @@ Consider splitting into smaller PRs for easier review.
 ''',
             },
 
+            # DEPRECATED: pre_commit_review is deprecated since v2.6.
+            # The /pre-commit command remains available for voluntary use.
             'pre_commit_review': {
-                'enabled': True,
+                'enabled': False,
+                'deprecated': True,
+                'deprecated_message': 'pre_commit_review is deprecated. Use /pre-commit voluntarily or /deep-review for enforced pre-PR review.',
                 'type': 'blocking',
                 'scope': 'single_use',
                 'trigger_tools': [

--- a/plugins/requirements-framework/README.md
+++ b/plugins/requirements-framework/README.md
@@ -112,7 +112,7 @@ Fast pre-commit review with smart agent selection.
 /requirements-framework:pre-commit tests types  # Specific aspects
 ```
 
-**Integration:** Auto-satisfies `pre_commit_review` requirement when complete
+**Integration:** Auto-satisfies `pre_commit_review` requirement when complete (requirement deprecated since v2.6, command remains available for voluntary use)
 
 **Workflow:**
 ```
@@ -120,7 +120,7 @@ Tool Validator (blocking gate)
       ↓ (if passes)
 Selected AI Agents (parallel or sequential)
       ↓
-Review Complete → auto-satisfy-skills.py → pre_commit_review satisfied
+Review Complete → auto-satisfy-skills.py → pre_commit_review satisfied (if enabled)
 ```
 
 #### /requirements-framework:quality-check [parallel]
@@ -407,13 +407,8 @@ See [Configuration System](../../README.md#configuration-system) for details.
 **Example ~/.claude/requirements.yaml:**
 ```yaml
 requirements:
-  pre_commit_review:
-    scope: single_use
-    message: "Run /requirements-framework:pre-commit before committing"
-    trigger_tools:
-      - tool: Write
-      - tool: Edit
-
+  # NOTE: pre_commit_review is deprecated since v2.6.
+  # Use /pre-commit voluntarily or /deep-review for enforced review.
   pre_pr_review:
     scope: single_use
     message: "Run /requirements-framework:quality-check before creating PR"
@@ -437,7 +432,7 @@ The plugin integrates via `auto-satisfy-skills.py` (PostToolUse hook):
 
 | Command | Satisfies | Scope |
 |---------|-----------|-------|
-| `/requirements-framework:pre-commit` | `pre_commit_review` | `single_use` |
+| `/requirements-framework:pre-commit` | `pre_commit_review` (deprecated) | `single_use` |
 | `/requirements-framework:quality-check` | `pre_pr_review` | `single_use` |
 | `/requirements-framework:codex-review` | `codex_reviewer` | `single_use` |
 
@@ -643,13 +638,13 @@ gh pr create
 # Try to edit file
 vim src/critical.ts
 
-# Blocked: "pre_commit_review not satisfied"
+# Blocked: "pre_pr_review not satisfied"
 
 # Satisfy requirement
-/requirements-framework:pre-commit
+/requirements-framework:deep-review
 
 # Now unblocked
-vim src/critical.ts  # Works!
+gh pr create  # Works!
 ```
 
 ## Limitations

--- a/plugins/requirements-framework/commands/pre-commit.md
+++ b/plugins/requirements-framework/commands/pre-commit.md
@@ -344,7 +344,7 @@ When subagent fallback was used (USE_TEAM=false or TeamCreate failed):
 |--------|-------------|--------------|
 | Scope | Pre-commit changes | All branch changes |
 | Default agents | code-reviewer + silent-failure-hunter | code-reviewer + silent-failure-hunter + contextual |
-| Satisfies | `pre_commit_review` | `pre_pr_review` |
+| Satisfies | `pre_commit_review` (deprecated) | `pre_pr_review` |
 | Cost | Lower (fewer default agents) | Higher (more agents, broader scope) |
 | Cross-validation | Yes (when 2+ review agents) | Always |
 

--- a/plugins/requirements-framework/skills/requesting-code-review/SKILL.md
+++ b/plugins/requirements-framework/skills/requesting-code-review/SKILL.md
@@ -75,7 +75,7 @@ Use Task tool with `requirements-framework:code-reviewer` type, fill template at
 
 ## Requirements Integration
 
-When this skill completes, it auto-satisfies the `pre_commit_review` requirement. This means git commit will no longer be blocked.
+When this skill completes, it auto-satisfies the `pre_commit_review` requirement (deprecated since v2.6, disabled by default). The `/pre-commit` command remains available for voluntary use.
 
 ## Red Flags
 

--- a/plugins/requirements-framework/skills/requirements-framework-usage/examples/project-requirements.yaml
+++ b/plugins/requirements-framework/skills/requirements-framework-usage/examples/project-requirements.yaml
@@ -46,9 +46,10 @@ requirements:
       - "Reviewed decision context"
       - "Confirmed approach aligns with ADRs"
 
-  # Pre-commit Review - Code quality gate
+  # Pre-commit Review - DEPRECATED since v2.6 (use /pre-commit voluntarily)
   pre_commit_review:
-    enabled: true
+    enabled: false  # Deprecated
+    deprecated: true
     scope: single_use
     trigger_tools:
       - tool: Bash

--- a/plugins/requirements-framework/skills/requirements-framework-usage/examples/single-use-pre-commit.yaml
+++ b/plugins/requirements-framework/skills/requirements-framework-usage/examples/single-use-pre-commit.yaml
@@ -1,7 +1,10 @@
 # Example: Single-Use Pre-commit Review
 #
-# Configuration for requiring code review before EVERY commit.
-# The single_use scope ensures the requirement resets after each commit.
+# DEPRECATED: pre_commit_review is deprecated since v2.6.
+# The /pre-commit command remains available for voluntary use.
+# Use /deep-review or /arch-review for enforced review workflows instead.
+#
+# This example is kept for reference only. The requirement is disabled by default.
 
 version: "1.0"
 enabled: true
@@ -9,7 +12,8 @@ inherit: true
 
 requirements:
   pre_commit_review:
-    enabled: true
+    enabled: false  # Deprecated since v2.6
+    deprecated: true
     type: blocking
     scope: single_use     # KEY: Resets after each commit
     trigger_tools:

--- a/plugins/requirements-framework/skills/requirements-framework-usage/examples/team-strict-config.yaml
+++ b/plugins/requirements-framework/skills/requirements-framework-usage/examples/team-strict-config.yaml
@@ -54,9 +54,10 @@ requirements:
       - "Reviewed decision context"
       - "Confirmed approach aligns with ADRs"
 
-  # Pre-commit Review - Code quality before each commit
+  # Pre-commit Review - DEPRECATED since v2.6 (use /pre-commit voluntarily)
   pre_commit_review:
-    enabled: true
+    enabled: false  # Deprecated
+    deprecated: true
     type: blocking
     scope: single_use
     trigger_tools:


### PR DESCRIPTION
## Summary

- Disables `pre_commit_review` requirement for all projects (`enabled: false`)
- Marks it as deprecated with `deprecated: true` and `deprecated_message` fields
- Updates feature catalog, init presets, and feature selector defaults
- Updates documentation across 16 files (configs, docs, plugin README, skills, examples)
- Keeps auto-satisfy mapping and `/pre-commit` command functional for voluntary use

Closes #80

## Test plan

- [x] All 1078 tests pass
- [x] `/pre-commit` command remains usable (not removed)
- [x] Auto-satisfy mapping kept in `auto-satisfy-skills.py` for backward compat
- [x] `req init` no longer defaults `pre_commit_review` to selected
- [x] Feature catalog marks it as deprecated with `default_enabled: False`