### PR TITLE
feat: auto-invoke brainstorming on plan mode entry

### DIFF
--- a/.claude/requirements.yaml
+++ b/.claude/requirements.yaml
@@ -225,4 +225,6 @@ hooks:
     min_tool_uses: 5
   stop:
     verify_requirements: true
+  plan_enter:
+    brainstorm_on_enter: true
 inherit: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,10 @@ PostToolUse (clear-single-use.py) - after certain Bash commands
     → Clears single_use requirements after trigger commands
     → Example: Clears single_use requirements after trigger commands
 
+PostToolUse (handle-plan-enter.py) - after EnterPlanMode
+    → Auto-invoke brainstorming skill if design_approved not satisfied
+    → Configurable via hooks.plan_enter.brainstorm_on_enter (default: true)
+
 PostToolUse (handle-plan-exit.py) - after ExitPlanMode
     → Shows requirements status proactively
     → Fires before any Edit attempts begin
@@ -113,6 +117,7 @@ TaskCompleted (handle-task-completed.py) - when team task completes (ADR-012)
 - `handle-session-start.py` - SessionStart hook (context injection)
 - `handle-prompt-submit.py` - UserPromptSubmit hook (prompt context injection)
 - `handle-permission-request.py` - PermissionRequest hook (auto-deny dangerous commands)
+- `handle-plan-enter.py` - PostToolUse hook for EnterPlanMode (brainstorm auto-invoke)
 - `handle-plan-exit.py` - PostToolUse hook for ExitPlanMode
 - `auto-satisfy-skills.py` - PostToolUse hook for skill completion
 - `clear-single-use.py` - PostToolUse hook for clearing single-use requirements

--- a/hooks/handle-plan-enter.py
+++ b/hooks/handle-plan-enter.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+PostToolUse Hook for EnterPlanMode - auto-invoke brainstorming skill.
+
+Fires when Claude enters plan mode, injecting a directive to invoke the
+brainstorming skill before writing the implementation plan. This ensures
+structured design exploration (questions, approaches, trade-offs) happens
+before planning begins.
+
+Input (stdin JSON):
+{
+    "tool_name": "EnterPlanMode",
+    "tool_input": {...},
+    "tool_result": {...},
+    "session_id": "abc123",
+    "cwd": "/path/to/project"
+}
+
+Output:
+- Structured JSON with hookSpecificOutput.additionalContext (shown to Claude in context)
+- Empty if brainstorming not needed
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add lib to path
+lib_path = Path(__file__).parent / 'lib'
+sys.path.insert(0, str(lib_path))
+
+from requirements import BranchRequirements
+from session import normalize_session_id
+from logger import get_logger
+from hook_utils import early_hook_setup
+from console import emit_hook_context
+
+BRAINSTORM_DIRECTIVE = """\
+## Brainstorm Before Planning
+
+Before writing your implementation plan, invoke the brainstorming skill to design the approach first.
+
+**Action**: Invoke `/brainstorming` now.
+
+The brainstorm will help you explore the problem, ask clarifying questions, propose approaches, and validate the design — all inside plan mode.
+
+**Important**: Write the design output directly into the plan file. Do NOT create a separate design document or attempt git commits during brainstorming."""
+
+
+def main() -> int:
+    """Hook entry point."""
+    # Parse stdin input
+    input_data = {}
+    try:
+        stdin_content = sys.stdin.read()
+        if stdin_content:
+            input_data = json.loads(stdin_content)
+    except json.JSONDecodeError as e:
+        logger = get_logger(base_context={"hook": "PlanEnter"})
+        logger.error(
+            "Failed to parse hook input JSON",
+            error=str(e),
+            stdin_preview=stdin_content[:200] if stdin_content else "empty"
+        )
+
+    # Only run this hook for EnterPlanMode tool
+    tool_name = input_data.get('tool_name')
+    if tool_name != 'EnterPlanMode':
+        return 0  # Silent skip for other tools
+
+    # Get session ID from stdin
+    raw_session = input_data.get('session_id')
+    if not raw_session:
+        logger = get_logger(base_context={"hook": "PlanEnter"})
+        logger.error("No session_id in hook input!", input_keys=list(input_data.keys()))
+        return 0  # Fail open
+
+    session_id = normalize_session_id(raw_session)
+
+    # Early hook setup: loads config, creates logger with correct level
+    project_dir, branch, config, logger = early_hook_setup(
+        session_id, "PlanEnter", cwd=input_data.get('cwd')
+    )
+
+    try:
+        # Skip if requirements explicitly disabled
+        if os.environ.get('CLAUDE_SKIP_REQUIREMENTS'):
+            return 0
+
+        # Skip if no project context
+        if not project_dir or not branch or not config:
+            return 0
+
+        # Skip if framework disabled
+        if not config.is_enabled():
+            return 0
+
+        # Check config: brainstorm_on_enter (default: True)
+        if not config.get_hook_config('plan_enter', 'brainstorm_on_enter', True):
+            logger.info("Brainstorm on enter disabled by config")
+            return 0
+
+        # Check if design_approved requirement exists AND is already satisfied
+        req_config = config.get_requirement('design_approved')
+        if req_config and config.is_requirement_enabled('design_approved'):
+            reqs = BranchRequirements(branch, session_id, project_dir)
+            scope = req_config.get('scope', 'session')
+            if reqs.is_satisfied('design_approved', scope):
+                logger.info("design_approved already satisfied, skipping brainstorm directive")
+                return 0
+
+        # Emit brainstorm directive
+        emit_hook_context("PostToolUse", BRAINSTORM_DIRECTIVE)
+        logger.info("Plan enter - injected brainstorm directive")
+        return 0
+
+    except Exception as e:
+        # FAIL OPEN - never block on errors
+        logger.error("Unhandled error in PlanEnter hook", error=str(e))
+        return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/hooks/handle-plan-enter.py
+++ b/hooks/handle-plan-enter.py
@@ -51,6 +51,7 @@ def main() -> int:
     """Hook entry point."""
     # Parse stdin input
     input_data = {}
+    stdin_content = ""
     try:
         stdin_content = sys.stdin.read()
         if stdin_content:

--- a/hooks/lib/config.py
+++ b/hooks/lib/config.py
@@ -755,6 +755,9 @@ class RequirementsConfig:
         "session_end": {
             "clear_session_state": False,
         },
+        "plan_enter": {
+            "brainstorm_on_enter": True,
+        },
     }
 
     def __init__(

--- a/hooks/lib/feature_catalog.py
+++ b/hooks/lib/feature_catalog.py
@@ -392,6 +392,17 @@ FEATURE_CATALOG: Dict[str, Dict[str, Any]] = {
   stop:
     verify_requirements: true""",
     },
+    "brainstorm_on_enter": {
+        "name": "Brainstorm on Plan Enter",
+        "category": CATEGORY_HOOKS,
+        "config_path": "hooks.plan_enter",
+        "description": "Auto-invoke brainstorming skill when entering plan mode",
+        "introduced": "2.6",
+        "default_enabled": True,
+        "example_yaml": """hooks:
+  plan_enter:
+    brainstorm_on_enter: true""",
+    },
 }
 
 

--- a/hooks/test_requirements.py
+++ b/hooks/test_requirements.py
@@ -9294,6 +9294,151 @@ def test_plugin_command_files_exist(runner: TestRunner):
                    filepath.exists())
 
 
+def test_plan_enter_hook(runner: TestRunner):
+    """Test handle-plan-enter.py PostToolUse hook behavior."""
+    print("\n📦 Testing PlanEnter hook...")
+
+    hook_path = Path(__file__).parent / "handle-plan-enter.py"
+
+    if not hook_path.exists():
+        runner.test("PlanEnter hook exists", False, "Hook file not implemented yet")
+        return
+
+    def run_hook(input_data, cwd, env=None):
+        return subprocess.run(
+            ["python3", str(hook_path)],
+            input=json.dumps(input_data),
+            cwd=cwd, capture_output=True, text=True,
+            env={**os.environ, **(env or {})}
+        )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Initialize git repo with feature branch
+        subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True)
+        subprocess.run(["git", "checkout", "-b", "feature/test"], cwd=tmpdir, capture_output=True)
+
+        base_input = {
+            "tool_name": "EnterPlanMode",
+            "tool_input": {},
+            "tool_result": {},
+            "session_id": "planenter-test"
+        }
+
+        # Test 1: Injects brainstorm directive with config (no design_approved requirement)
+        os.makedirs(f"{tmpdir}/.claude")
+        config = {
+            "version": "1.0",
+            "enabled": True,
+            "inherit": False,
+            "requirements": {
+                "commit_plan": {"enabled": True, "scope": "session", "message": "Plan!"}
+            }
+        }
+        with open(f"{tmpdir}/.claude/requirements.yaml", 'w') as f:
+            json.dump(config, f)
+
+        result = run_hook(base_input, tmpdir)
+        ctx = extract_hook_context(result.stdout)
+        runner.test("Injects brainstorm directive",
+                   "Brainstorm Before Planning" in ctx and "/brainstorming" in ctx,
+                   f"Got: {result.stdout[:300]}")
+        runner.test("Injects directive exit 0", result.returncode == 0)
+
+        # Test 2: Fires without design_approved requirement configured
+        config_no_design = {
+            "version": "1.0",
+            "enabled": True,
+            "inherit": False,
+            "requirements": {}
+        }
+        with open(f"{tmpdir}/.claude/requirements.yaml", 'w') as f:
+            json.dump(config_no_design, f)
+
+        result = run_hook(base_input, tmpdir)
+        ctx = extract_hook_context(result.stdout)
+        runner.test("Fires without design_approved requirement",
+                   "Brainstorm Before Planning" in ctx,
+                   f"Got: {result.stdout[:300]}")
+
+        # Test 3: Skips non-EnterPlanMode tool
+        non_enter_input = {**base_input, "tool_name": "ExitPlanMode"}
+        result = run_hook(non_enter_input, tmpdir)
+        runner.test("Skips non-EnterPlanMode tool",
+                   result.returncode == 0 and result.stdout.strip() == "",
+                   f"Got output: {result.stdout[:200]}")
+
+        # Test 4: Skips when design_approved is satisfied
+        config_with_design = {
+            "version": "1.0",
+            "enabled": True,
+            "inherit": False,
+            "requirements": {
+                "design_approved": {"enabled": True, "scope": "session", "type": "blocking", "message": "Design!"}
+            }
+        }
+        with open(f"{tmpdir}/.claude/requirements.yaml", 'w') as f:
+            json.dump(config_with_design, f)
+
+        # Satisfy design_approved via BranchRequirements
+        from requirements import BranchRequirements
+        reqs = BranchRequirements("feature/test", "planenter-test", tmpdir)
+        reqs.satisfy("design_approved", "session")
+
+        result = run_hook(base_input, tmpdir)
+        runner.test("Skips when design_approved satisfied",
+                   result.stdout.strip() == "",
+                   f"Expected empty output, got: {result.stdout[:200]}")
+
+        # Test 5: Skips when config disabled
+        config_disabled = {
+            "version": "1.0",
+            "enabled": True,
+            "inherit": False,
+            "hooks": {
+                "plan_enter": {"brainstorm_on_enter": False}
+            },
+            "requirements": {}
+        }
+        with open(f"{tmpdir}/.claude/requirements.yaml", 'w') as f:
+            json.dump(config_disabled, f)
+
+        result = run_hook(base_input, tmpdir)
+        runner.test("Skips when brainstorm_on_enter disabled",
+                   result.returncode == 0 and result.stdout.strip() == "",
+                   f"Got output: {result.stdout[:200]}")
+
+        # Test 6: Skips when framework disabled
+        config_fw_disabled = {
+            "version": "1.0",
+            "enabled": False,
+            "inherit": False,
+            "requirements": {}
+        }
+        with open(f"{tmpdir}/.claude/requirements.yaml", 'w') as f:
+            json.dump(config_fw_disabled, f)
+
+        result = run_hook(base_input, tmpdir)
+        runner.test("Skips when framework disabled",
+                   result.returncode == 0 and result.stdout.strip() == "",
+                   f"Got output: {result.stdout[:200]}")
+
+        # Test 7: Fails open on error (bad JSON stdin)
+        result = subprocess.run(
+            ["python3", str(hook_path)],
+            input="not valid json",
+            cwd=tmpdir, capture_output=True, text=True
+        )
+        runner.test("Fails open on bad JSON", result.returncode == 0)
+
+    # Test 8: Config default value
+    from config import RequirementsConfig
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cfg = RequirementsConfig(tmpdir)
+        val = cfg.get_hook_config('plan_enter', 'brainstorm_on_enter')
+        runner.test("Hook default brainstorm_on_enter is True", val is True,
+                   f"Got: {val}")
+
+
 def main():
     """Run all tests."""
     print("🧪 Requirements Framework Test Suite")
@@ -9468,6 +9613,9 @@ def main():
     test_plugin_skill_files_exist(runner)
     test_plugin_command_files_exist(runner)
     test_session_start_bootstrap_injection(runner)
+
+    # Plan enter hook tests
+    test_plan_enter_hook(runner)
 
     return runner.summary()
 

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,7 @@ cp -v "$REPO_DIR/hooks/handle-session-end.py" "$HOME/.claude/hooks/"
 cp -v "$REPO_DIR/hooks/auto-satisfy-skills.py" "$HOME/.claude/hooks/"
 cp -v "$REPO_DIR/hooks/clear-single-use.py" "$HOME/.claude/hooks/"
 cp -v "$REPO_DIR/hooks/handle-plan-exit.py" "$HOME/.claude/hooks/"
+cp -v "$REPO_DIR/hooks/handle-plan-enter.py" "$HOME/.claude/hooks/"
 cp -v "$REPO_DIR/hooks/ruff_check.py" "$HOME/.claude/hooks/"
 cp -v "$REPO_DIR/hooks/handle-teammate-idle.py" "$HOME/.claude/hooks/"
 cp -v "$REPO_DIR/hooks/handle-task-completed.py" "$HOME/.claude/hooks/"
@@ -50,6 +51,7 @@ chmod +x "$HOME/.claude/hooks/handle-session-end.py"
 chmod +x "$HOME/.claude/hooks/auto-satisfy-skills.py"
 chmod +x "$HOME/.claude/hooks/clear-single-use.py"
 chmod +x "$HOME/.claude/hooks/handle-plan-exit.py"
+chmod +x "$HOME/.claude/hooks/handle-plan-enter.py"
 chmod +x "$HOME/.claude/hooks/ruff_check.py"
 chmod +x "$HOME/.claude/hooks/handle-teammate-idle.py"
 chmod +x "$HOME/.claude/hooks/handle-task-completed.py"
@@ -309,7 +311,8 @@ REQUIRED_HOOKS = {
         "hooks": [
             {"type": "command", "command": "~/.claude/hooks/auto-satisfy-skills.py"},
             {"type": "command", "command": "~/.claude/hooks/clear-single-use.py"},
-            {"type": "command", "command": "~/.claude/hooks/handle-plan-exit.py"}
+            {"type": "command", "command": "~/.claude/hooks/handle-plan-exit.py"},
+            {"type": "command", "command": "~/.claude/hooks/handle-plan-enter.py"}
         ]
     }],
     "SessionStart": [{

--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "description": "Claude Code Requirements Framework - Complete development lifecycle from ideation to completion. Enforces workflow requirements through hooks, guides process with 19 development skills (brainstorming, TDD, debugging, verification), and provides comprehensive code review agents.",
   "author": {
     "name": "Harm"

--- a/plugins/requirements-framework/hooks/hooks.json
+++ b/plugins/requirements-framework/hooks/hooks.json
@@ -43,6 +43,16 @@
             "statusMessage": "Validating plan requirements..."
           }
         ]
+      },
+      {
+        "matcher": "EnterPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/handle-plan-enter.py",
+            "statusMessage": "Checking brainstorm requirements..."
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/plugins/requirements-framework/skills/brainstorming/SKILL.md
+++ b/plugins/requirements-framework/skills/brainstorming/SKILL.md
@@ -92,6 +92,14 @@ digraph brainstorming {
 
 When this skill completes, it auto-satisfies the `design_approved` requirement. This means Edit/Write tools will no longer be blocked by the design gate (if your project has `design_approved` enabled).
 
+## Plan Mode Behavior
+
+When invoked inside plan mode:
+- Write the design directly into the plan file. Do NOT create a separate design document.
+- Skip the git commit step (step 5) — the plan file is your design doc.
+- After design approval, continue writing the implementation plan in the same plan file.
+- The `requirements-framework:writing-plans` invocation is optional in plan mode since you are already planning.
+
 ## Key Principles
 
 - **One question at a time** — Don't overwhelm with multiple questions


### PR DESCRIPTION
## Summary

- Add `handle-plan-enter.py` PostToolUse hook that fires on `EnterPlanMode` to inject a brainstorming directive into Claude's context
- When entering plan mode, Claude is now guided to invoke `/brainstorming` for structured design exploration before writing the implementation plan
- Enabled by default globally, opt-out via `hooks.plan_enter.brainstorm_on_enter: false`
- Skips if `design_approved` requirement already satisfied (avoids redundant brainstorming)

## Changes

| File | Change |
|------|--------|
| `hooks/handle-plan-enter.py` | New PostToolUse hook with fail-open semantics |
| `hooks/lib/config.py` | Add `plan_enter` to `HOOK_DEFAULTS` |
| `hooks/lib/feature_catalog.py` | Add `brainstorm_on_enter` feature entry |
| `hooks/test_requirements.py` | 9 new tests (1090/1090 total passing) |
| `install.sh` | Register hook in cp/chmod/REQUIRED_HOOKS |
| `plugins/.../hooks.json` | Add `EnterPlanMode` PostToolUse matcher |
| `plugins/.../SKILL.md` | Add "Plan Mode Behavior" section |
| `CLAUDE.md` | Add hook to lifecycle docs and key components |
| `.claude/requirements.yaml` | Add `plan_enter` config |
| `plugins/.../plugin.json` | Version bump 2.5.2 -> 2.6.0 |

## Review

Deep review completed: 0 CRITICAL, 4 IMPORTANT, 8 SUGGESTION. Verdict: **READY**.
Codex review completed: 0 CRITICAL, 0 IMPORTANT, 4 SUGGESTION. Verdict: **APPROVED**.

## Test plan

- [x] `python3 hooks/test_requirements.py` — 1090/1090 pass
- [x] Hook exits 0 on empty stdin, non-EnterPlanMode, bad JSON
- [x] Directive injected on EnterPlanMode with config enabled
- [x] Directive skipped when design_approved satisfied
- [x] Directive skipped when brainstorm_on_enter disabled
- [x] Directive skipped when framework disabled
- [ ] Manual: enter plan mode -> brainstorm directive appears
- [ ] Manual: satisfy design_approved, re-enter -> no directive
- [ ] Manual: set brainstorm_on_enter: false -> no directive