### PR TITLE
feat: add cross-project WIP tracking system

### DIFF
--- a/hooks/handle-git-events.py
+++ b/hooks/handle-git-events.py
@@ -86,16 +86,9 @@ def _handle_git_commit(tracker, project_dir: str, branch: str, logger) -> None:
                 lines_removed = int(m.group(3) or 0)
                 break
 
-    # Get current commit count
-    entry = tracker.get_entry(project_dir, branch)
-    current_count = 0
-    if entry:
-        current_count = entry.get("git_metrics", {}).get("commit_count", 0)
-
-    tracker.update_git_metrics(
+    tracker.record_commit(
         project_dir, branch,
-        commit_count=current_count + 1,
-        last_commit_hash=commit_hash,
+        commit_hash=commit_hash,
         files_changed=files_changed,
         lines_added=lines_added,
         lines_removed=lines_removed,
@@ -184,9 +177,14 @@ def main() -> int:
             tool_result = input_data.get('tool_result', {})
             _handle_pr_create(tracker, project_dir, branch, tool_result, logger)
 
-    except Exception:
+    except Exception as e:
         # Fail silently - never block on tracking errors
-        pass
+        try:
+            get_logger(base_context={"hook": "GitEvents"}).error(
+                "Unhandled error in GitEvents hook", error=str(e)
+            )
+        except Exception:
+            pass
 
     return 0
 

--- a/hooks/handle-git-events.py
+++ b/hooks/handle-git-events.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+PostToolUse hook for Bash - tracks git events for WIP tracking.
+
+Monitors Bash tool completions for git commit, git push, and gh pr create
+commands. Updates WipTracker git metrics accordingly.
+
+Input (stdin):
+    JSON with tool completion details:
+    {
+        "tool_name": "Bash",
+        "tool_input": {"command": "git commit -m 'feat: add auth'"},
+        "tool_result": {"stdout": "...", "stderr": "..."},
+        "session_id": "abc12345"
+    }
+
+Output:
+    None (logging only)
+
+Environment:
+    CLAUDE_PROJECT_DIR: Project directory (defaults to cwd)
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+# Add lib to path
+lib_path = Path(__file__).parent / 'lib'
+sys.path.insert(0, str(lib_path))
+
+from git_utils import get_current_branch, is_git_repo, resolve_project_root, run_git
+from hook_utils import extract_command
+from logger import get_logger
+
+
+def _is_wip_enabled(project_dir: str) -> bool:
+    """Check if WIP tracking is enabled for this project."""
+    try:
+        from config import RequirementsConfig
+        config = RequirementsConfig(project_dir)
+        return config.get_hook_config('wip_tracking', 'enabled', False)
+    except Exception:
+        return False
+
+
+def _get_exclude_branches(project_dir: str) -> list[str]:
+    """Get list of branches to exclude from WIP tracking."""
+    try:
+        from config import RequirementsConfig
+        config = RequirementsConfig(project_dir)
+        return config.get_hook_config(
+            'wip_tracking', 'exclude_branches',
+            ['main', 'master', 'develop']
+        )
+    except Exception:
+        return ['main', 'master', 'develop']
+
+
+def _handle_git_commit(tracker, project_dir: str, branch: str, logger) -> None:
+    """Handle git commit: update commit count, hash, and diff stats."""
+    # Get latest commit hash
+    exit_code, commit_hash, _ = run_git("git rev-parse HEAD", cwd=project_dir)
+    if exit_code != 0:
+        return
+
+    # Get diff stats for the latest commit
+    exit_code, stat_output, _ = run_git(
+        "git diff --stat HEAD~1 HEAD", cwd=project_dir
+    )
+    files_changed = 0
+    lines_added = 0
+    lines_removed = 0
+    if exit_code == 0 and stat_output:
+        # Parse summary line: " 3 files changed, 10 insertions(+), 2 deletions(-)"
+        for line in stat_output.splitlines():
+            m = re.search(
+                r'(\d+) files? changed'
+                r'(?:, (\d+) insertions?\(\+\))?'
+                r'(?:, (\d+) deletions?\(-\))?',
+                line
+            )
+            if m:
+                files_changed = int(m.group(1))
+                lines_added = int(m.group(2) or 0)
+                lines_removed = int(m.group(3) or 0)
+                break
+
+    # Get current commit count
+    entry = tracker.get_entry(project_dir, branch)
+    current_count = 0
+    if entry:
+        current_count = entry.get("git_metrics", {}).get("commit_count", 0)
+
+    tracker.update_git_metrics(
+        project_dir, branch,
+        commit_count=current_count + 1,
+        last_commit_hash=commit_hash,
+        files_changed=files_changed,
+        lines_added=lines_added,
+        lines_removed=lines_removed,
+    )
+    logger.info("Tracked git commit", commit_hash=commit_hash[:8])
+
+
+def _handle_git_push(tracker, project_dir: str, branch: str, logger) -> None:
+    """Handle git push: mark branch as pushed."""
+    tracker.update_git_metrics(project_dir, branch, pushed=True)
+    logger.info("Tracked git push")
+
+
+def _handle_pr_create(tracker, project_dir: str, branch: str,
+                      tool_result: dict, logger) -> None:
+    """Handle gh pr create: extract PR URL from output."""
+    stdout = tool_result.get("stdout", "")
+    # gh pr create outputs the PR URL on the last line
+    pr_url = None
+    for line in stdout.splitlines():
+        line = line.strip()
+        if re.match(r'https://github\.com/.+/pull/\d+', line):
+            pr_url = line
+            break
+
+    if pr_url:
+        tracker.update_git_metrics(project_dir, branch, pr_url=pr_url)
+        logger.info("Tracked PR creation", pr_url=pr_url)
+
+
+def main() -> int:
+    """Hook entry point."""
+    try:
+        # Read hook input
+        input_data = {}
+        try:
+            stdin_content = sys.stdin.read()
+            if stdin_content:
+                input_data = json.loads(stdin_content)
+        except json.JSONDecodeError:
+            return 0
+
+        tool_name = input_data.get('tool_name', '')
+
+        # Only process Bash tool completions
+        if tool_name != 'Bash':
+            return 0
+
+        tool_input = input_data.get('tool_input', {})
+        command = extract_command(tool_input)
+        if not command:
+            return 0
+
+        # Get project context
+        project_dir = resolve_project_root(verbose=False)
+
+        # Check if WIP tracking is enabled
+        if not _is_wip_enabled(project_dir):
+            return 0
+
+        # Must be a git repo
+        if not is_git_repo(project_dir):
+            return 0
+
+        branch = get_current_branch(project_dir)
+        if not branch:
+            return 0
+
+        # Skip excluded branches
+        exclude = _get_exclude_branches(project_dir)
+        if branch in exclude:
+            return 0
+
+        logger = get_logger(base_context={"hook": "GitEvents"})
+
+        # Lazy import to avoid loading WipTracker when not needed
+        from wip_tracker import WipTracker
+        tracker = WipTracker()
+
+        # Match command patterns
+        if re.match(r'git\s+commit\b', command):
+            _handle_git_commit(tracker, project_dir, branch, logger)
+        elif re.match(r'git\s+push\b', command):
+            _handle_git_push(tracker, project_dir, branch, logger)
+        elif re.match(r'gh\s+pr\s+create\b', command):
+            tool_result = input_data.get('tool_result', {})
+            _handle_pr_create(tracker, project_dir, branch, tool_result, logger)
+
+    except Exception:
+        # Fail silently - never block on tracking errors
+        pass
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/hooks/handle-plan-exit.py
+++ b/hooks/handle-plan-exit.py
@@ -171,6 +171,42 @@ def main() -> int:
         emit_hook_context("PostToolUse", "\n".join(lines))
 
         logger.info("Plan exit - showed requirements", requirements=req_names)
+
+        # WIP tracking: auto-create/update entry from plan context (silent)
+        try:
+            wip_enabled = config.get_hook_config('wip_tracking', 'enabled', False)
+            exclude_branches = config.get_hook_config(
+                'wip_tracking', 'exclude_branches',
+                ['main', 'master', 'develop']
+            )
+            if wip_enabled and branch not in exclude_branches:
+                import re
+                from wip_tracker import WipTracker
+
+                tracker = WipTracker()
+                updates = {"status": "wip"}
+
+                # Auto-generate summary from plan path if available
+                plan_path = input_data.get('tool_result', {}).get('plan_path', '')
+                if plan_path:
+                    updates["plan_path"] = plan_path
+                    # Extract readable name from filename
+                    name = Path(plan_path).stem
+                    # Strip UUID prefixes (common in plan files)
+                    name = re.sub(r'^[a-f0-9]{8}-[a-f0-9-]+_?', '', name)
+                    if name:
+                        updates["summary"] = name.replace('-', ' ').replace('_', ' ')[:80]
+
+                # Detect github issue from branch name patterns
+                m = re.search(r'(?:feature|fix|issue|bug)[/-](\d+)', branch)
+                if m:
+                    updates["github_issue"] = f"#{m.group(1)}"
+
+                tracker.upsert_entry(project_dir, branch, updates)
+                logger.debug("WIP entry created/updated from plan exit")
+        except Exception as e:
+            logger.debug("WIP tracking in plan-exit failed (fail-open)", error=str(e))
+
         return 0
 
     except Exception as e:

--- a/hooks/handle-session-end.py
+++ b/hooks/handle-session-end.py
@@ -74,6 +74,17 @@ def main() -> int:
 
         logger.info("Session ending", reason=reason)
 
+        # 0. Read session start time before registry removal (for WIP time tracking)
+        session_started_at = None
+        try:
+            from registry_client import RegistryClient
+            reg_client = RegistryClient(session.get_registry_path())
+            reg_data = reg_client.read()
+            session_entry = reg_data.get("sessions", {}).get(session_id, {})
+            session_started_at = session_entry.get("started_at")
+        except Exception:
+            pass
+
         # 1. Remove session from registry
         removed = remove_session_from_registry(session_id)
         if removed:
@@ -93,6 +104,28 @@ def main() -> int:
                         logger.debug("Cleared session requirement", requirement=req_name)
                     except Exception as e:
                         logger.error("Failed to clear requirement", requirement=req_name, error=str(e))
+
+        # 3. WIP tracking: accumulate session time
+        try:
+            wip_enabled = config and config.get_hook_config('wip_tracking', 'enabled', False)
+            exclude_branches = (
+                config.get_hook_config('wip_tracking', 'exclude_branches',
+                                       ['main', 'master', 'develop'])
+                if config else ['main', 'master', 'develop']
+            )
+
+            if wip_enabled and branch and branch not in exclude_branches:
+                import time
+                from wip_tracker import WipTracker
+
+                if session_started_at:
+                    elapsed = time.time() - session_started_at
+                    if elapsed > 0:
+                        tracker = WipTracker()
+                        tracker.increment_time(project_dir, branch, elapsed)
+                        logger.debug("WIP time tracked", elapsed_seconds=int(elapsed))
+        except Exception as e:
+            logger.debug("WIP time tracking failed (fail-open)", error=str(e))
 
         return 0
 

--- a/hooks/handle-session-end.py
+++ b/hooks/handle-session-end.py
@@ -29,7 +29,7 @@ lib_path = Path(__file__).parent / 'lib'
 sys.path.insert(0, str(lib_path))
 
 from requirements import BranchRequirements
-from session import remove_session_from_registry, normalize_session_id
+from session import remove_session_from_registry, normalize_session_id, get_registry_path
 from logger import get_logger
 from hook_utils import early_hook_setup
 
@@ -78,7 +78,7 @@ def main() -> int:
         session_started_at = None
         try:
             from registry_client import RegistryClient
-            reg_client = RegistryClient(session.get_registry_path())
+            reg_client = RegistryClient(get_registry_path())
             reg_data = reg_client.read()
             session_entry = reg_data.get("sessions", {}).get(session_id, {})
             session_started_at = session_entry.get("started_at")

--- a/hooks/handle-session-start.py
+++ b/hooks/handle-session-start.py
@@ -643,7 +643,50 @@ See `req init --help` for options.""")
             # Fail silently - this is opportunistic
             logger.debug("Failed to register project", error=str(e))
 
-        # 2c. Check for other sessions and warn if single_session guard is enabled
+        # 2c. WIP tracking: register session and detect merged branches
+        wip_summary = None
+        try:
+            wip_enabled = config.get_hook_config('wip_tracking', 'enabled', False)
+            wip_inject = config.get_hook_config('wip_tracking', 'inject_on_start', True)
+            exclude_branches = config.get_hook_config(
+                'wip_tracking', 'exclude_branches',
+                ['main', 'master', 'develop']
+            )
+
+            if wip_enabled and branch not in exclude_branches:
+                from wip_tracker import WipTracker
+                tracker = WipTracker()
+                tracker.add_session(project_dir, branch, session_id)
+
+                # Auto-detect merged branches
+                merged = []
+                if config.get_hook_config('wip_tracking', 'auto_detect_merged', True):
+                    merged = tracker.check_merged_branches(project_dir)
+
+                # Build WIP summary for context injection
+                if wip_inject:
+                    entries = tracker.list_entries()
+                    # Filter out done entries for the summary
+                    active = [e for e in entries if e.get("status") != "done"]
+                    if active:
+                        lines = ["### WIP Branches", "| Branch | Status | Summary | Commits |",
+                                 "|--------|--------|---------|---------|"]
+                        for e in active[:10]:  # Cap at 10 entries
+                            proj_name = Path(e["project_dir"]).name
+                            b = e.get("branch", "?")
+                            s = e.get("status", "?").upper()
+                            summary = e.get("summary", "")[:40]
+                            commits = e.get("git_metrics", {}).get("commit_count", 0)
+                            lines.append(f"| {proj_name}/{b} | {s} | {summary} | {commits} |")
+                        if merged:
+                            lines.append(f"\n{len(merged)} branch(es) merged since last session (auto-marked DONE)")
+                        wip_summary = "\n".join(lines)
+
+                logger.debug("WIP tracking initialized", entries=len(active) if wip_inject and 'active' in dir() else 0)
+        except Exception as e:
+            logger.debug("WIP tracking failed (fail-open)", error=str(e))
+
+        # 2d. Check for other sessions and warn if single_session guard is enabled
         other_sessions_warning = check_other_sessions_warning(
             config, project_dir, session_id, logger
         )
@@ -652,6 +695,8 @@ See `req init --help` for options.""")
         inject_context = config.get_hook_config('session_start', 'inject_context', True)
 
         parts = []
+        if wip_summary:
+            parts.append(wip_summary)
         if other_sessions_warning:
             parts.append(other_sessions_warning)
         if inject_context:

--- a/hooks/handle-stop.py
+++ b/hooks/handle-stop.py
@@ -280,6 +280,50 @@ def main() -> int:
         else:
             logger.debug("All requirements satisfied - allowing stop")
 
+            # Check if we should prompt for WIP status update
+            try:
+                wip_enabled = config.get_hook_config('wip_tracking', 'enabled', False)
+                wip_prompt = config.get_hook_config('wip_tracking', 'prompt_on_stop', True)
+                exclude_branches = config.get_hook_config(
+                    'wip_tracking', 'exclude_branches',
+                    ['main', 'master', 'develop']
+                )
+
+                if wip_enabled and wip_prompt and branch not in exclude_branches:
+                    from wip_tracker import WipTracker
+                    tracker = WipTracker()
+                    entry = tracker.get_entry(project_dir, branch)
+
+                    if entry and entry.get("status") not in ("done",):
+                        metrics = entry.get("git_metrics", {})
+                        commits = metrics.get("commit_count", 0)
+                        pushed = metrics.get("pushed", False)
+                        pr_url = metrics.get("pr_url")
+
+                        details = f"{commits} commit(s)"
+                        if pushed:
+                            details += ", pushed"
+                        if pr_url:
+                            details += f", PR: {pr_url}"
+
+                        wip_lines = [
+                            "## WIP Status Update", "",
+                            f"Branch `{branch}` has {details}.", "",
+                            "Set branch status before finishing:",
+                            "- `req wip set wip` — Still in progress",
+                            "- `req wip set done` — Feature complete",
+                            "- `req wip set paused` — Pausing work",
+                            "- `req wip set todo` — Has remaining tasks",
+                        ]
+                        emit_json({
+                            "decision": "block",
+                            "reason": "\n".join(wip_lines)
+                        })
+                        logger.info("Blocked stop for WIP status prompt")
+                        return 0
+            except Exception as e:
+                logger.debug("WIP stop prompt failed (fail-open)", error=str(e))
+
             # Check if we should prompt for session review
             if _should_prompt_session_review(config, session_id, project_dir, branch, logger):
                 _emit_session_review_prompt(session_id, project_dir, branch, logger)

--- a/hooks/lib/config.py
+++ b/hooks/lib/config.py
@@ -758,6 +758,13 @@ class RequirementsConfig:
         "plan_enter": {
             "brainstorm_on_enter": True,
         },
+        "wip_tracking": {
+            "enabled": False,
+            "prompt_on_stop": True,
+            "inject_on_start": True,
+            "auto_detect_merged": True,
+            "exclude_branches": ["main", "master", "develop"],
+        },
     }
 
     def __init__(

--- a/hooks/lib/feature_catalog.py
+++ b/hooks/lib/feature_catalog.py
@@ -403,6 +403,24 @@ FEATURE_CATALOG: Dict[str, Dict[str, Any]] = {
   plan_enter:
     brainstorm_on_enter: true""",
     },
+    "wip_tracking": {
+        "name": "WIP Project Tracking",
+        "category": CATEGORY_HOOKS,
+        "config_path": "hooks.wip_tracking",
+        "description": "Track work-in-progress branches across projects",
+        "introduced": "2.7",
+        "default_enabled": False,
+        "example_yaml": """hooks:
+  wip_tracking:
+    enabled: true
+    prompt_on_stop: true
+    inject_on_start: true
+    auto_detect_merged: true
+    exclude_branches:
+      - main
+      - master
+      - develop""",
+    },
 }
 
 

--- a/hooks/lib/wip_tracker.py
+++ b/hooks/lib/wip_tracker.py
@@ -190,6 +190,38 @@ class WipTracker:
 
         return self._client.update(_update)
 
+    def record_commit(self, project_dir: str, branch: str,
+                      commit_hash: str, files_changed: int = 0,
+                      lines_added: int = 0, lines_removed: int = 0) -> bool:
+        """
+        Atomically increment commit count and update git metrics.
+
+        Args:
+            commit_hash: Latest commit hash
+            files_changed: Number of files changed
+            lines_added: Lines added
+            lines_removed: Lines removed
+
+        Returns:
+            True if successful, False on error.
+        """
+        key = self._make_key(project_dir, branch)
+
+        def _update(registry: dict) -> Optional[dict]:
+            entries = registry.get("entries", {})
+            if key not in entries:
+                return None
+            metrics = entries[key].setdefault("git_metrics", {})
+            metrics["commit_count"] = metrics.get("commit_count", 0) + 1
+            metrics["last_commit_hash"] = commit_hash
+            metrics["files_changed"] = files_changed
+            metrics["lines_added"] = lines_added
+            metrics["lines_removed"] = lines_removed
+            entries[key]["updated_at"] = time.time()
+            return registry
+
+        return self._client.update(_update)
+
     def increment_time(self, project_dir: str, branch: str, seconds: float) -> bool:
         """
         Add elapsed time to a WIP entry.
@@ -236,33 +268,31 @@ class WipTracker:
 
         merged = set()
         for line in stdout.splitlines():
-            branch = line.strip().lstrip("* ")
+            branch = line.strip().removeprefix("* ")
             if branch and branch not in ("main", "master", "develop"):
                 merged.add(branch)
 
         if not merged:
             return []
 
-        # Check WIP entries and mark merged ones as done
-        registry = self._client.read()
-        entries = registry.get("entries", {})
-        updated = False
+        # Atomically mark merged WIP entries as done
+        def _update(registry: dict) -> Optional[dict]:
+            entries = registry.get("entries", {})
+            changed = False
+            for key, entry in entries.items():
+                if (
+                    entry.get("project_dir") == project_dir
+                    and entry.get("branch") in merged
+                    and entry.get("status") != "done"
+                ):
+                    entry["status"] = "done"
+                    entry["updated_at"] = time.time()
+                    marked.append(entry["branch"])
+                    changed = True
+                    logger.info("Auto-marked merged branch as done", branch=entry["branch"])
+            return registry if changed else None
 
-        for key, entry in entries.items():
-            if (
-                entry.get("project_dir") == project_dir
-                and entry.get("branch") in merged
-                and entry.get("status") != "done"
-            ):
-                entry["status"] = "done"
-                entry["updated_at"] = time.time()
-                marked.append(entry["branch"])
-                updated = True
-                logger.info("Auto-marked merged branch as done", branch=entry["branch"])
-
-        if updated:
-            self._client.write(registry)
-
+        self._client.update(_update)
         return marked
 
     def list_entries(

--- a/hooks/lib/wip_tracker.py
+++ b/hooks/lib/wip_tracker.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""
+WIP Projects Tracker - Cross-project work-in-progress tracking.
+
+Tracks branch lifecycle from plan creation through merge across all projects.
+Uses RegistryClient for atomic file operations on ~/.claude/wip_projects.json.
+
+Storage Format:
+{
+    "version": "1.0",
+    "entries": {
+        "/path/to/project::feature/auth": {
+            "project_dir": "/path/to/project",
+            "branch": "feature/auth",
+            "status": "wip",
+            "summary": "...",
+            ...
+        }
+    }
+}
+"""
+
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from git_utils import run_git
+from logger import get_logger
+from registry_client import RegistryClient
+
+# Default storage location
+WIP_FILE = Path.home() / ".claude" / "wip_projects.json"
+
+# Valid statuses
+VALID_STATUSES = {"wip", "done", "paused", "todo"}
+
+
+def _empty_registry() -> dict:
+    """Return empty WIP registry structure."""
+    return {"version": "1.0", "entries": {}}
+
+
+def _new_entry(project_dir: str, branch: str) -> dict:
+    """Create a new WIP entry with defaults."""
+    now = time.time()
+    return {
+        "project_dir": project_dir,
+        "branch": branch,
+        "status": "wip",
+        "summary": "",
+        "github_issue": "",
+        "plan_path": "",
+        "session_id": "",
+        "session_history": [],
+        "created_at": now,
+        "updated_at": now,
+        "git_metrics": {
+            "commit_count": 0,
+            "files_changed": 0,
+            "lines_added": 0,
+            "lines_removed": 0,
+            "last_commit_hash": None,
+            "pushed": False,
+            "pr_url": None,
+        },
+        "total_time_seconds": 0,
+    }
+
+
+class WipTracker:
+    """
+    Cross-project WIP tracking with atomic file operations.
+
+    Uses RegistryClient for thread-safe, atomic read-modify-write.
+    All operations fail-open (errors don't block work).
+    """
+
+    def __init__(self, wip_path: Optional[Path] = None):
+        """
+        Initialize WIP tracker.
+
+        Args:
+            wip_path: Path to wip_projects.json (default: ~/.claude/wip_projects.json)
+        """
+        self._path = wip_path or WIP_FILE
+        self._client = RegistryClient(self._path)
+
+    def _make_key(self, project_dir: str, branch: str) -> str:
+        """Create composite key from project directory and branch."""
+        return f"{project_dir}::{branch}"
+
+    def get_entry(self, project_dir: str, branch: str) -> Optional[dict]:
+        """
+        Get a single WIP entry.
+
+        Returns:
+            Entry dict or None if not found.
+        """
+        registry = self._client.read()
+        entries = registry.get("entries", {})
+        return entries.get(self._make_key(project_dir, branch))
+
+    def upsert_entry(self, project_dir: str, branch: str, updates: dict) -> bool:
+        """
+        Create or update a WIP entry atomically.
+
+        Args:
+            project_dir: Project directory path
+            branch: Branch name
+            updates: Fields to set/update on the entry
+
+        Returns:
+            True if successful, False on error.
+        """
+        key = self._make_key(project_dir, branch)
+
+        def _update(registry: dict) -> dict:
+            if "entries" not in registry:
+                registry["entries"] = {}
+            if key not in registry["entries"]:
+                registry["entries"][key] = _new_entry(project_dir, branch)
+            entry = registry["entries"][key]
+            entry.update(updates)
+            entry["updated_at"] = time.time()
+            return registry
+
+        return self._client.update(_update)
+
+    def add_session(self, project_dir: str, branch: str, session_id: str) -> bool:
+        """
+        Register a session against a WIP entry.
+
+        Creates entry if it doesn't exist. Adds session_id to history
+        and sets it as the current session.
+
+        Returns:
+            True if successful, False on error.
+        """
+        key = self._make_key(project_dir, branch)
+
+        def _update(registry: dict) -> dict:
+            if "entries" not in registry:
+                registry["entries"] = {}
+            if key not in registry["entries"]:
+                registry["entries"][key] = _new_entry(project_dir, branch)
+            entry = registry["entries"][key]
+            entry["session_id"] = session_id
+            if session_id not in entry.get("session_history", []):
+                entry.setdefault("session_history", []).append(session_id)
+            entry["updated_at"] = time.time()
+            return registry
+
+        return self._client.update(_update)
+
+    def set_status(self, project_dir: str, branch: str, status: str) -> bool:
+        """
+        Update status of a WIP entry.
+
+        Args:
+            status: One of 'wip', 'done', 'paused', 'todo'
+
+        Returns:
+            True if successful, False on error or invalid status.
+        """
+        if status not in VALID_STATUSES:
+            return False
+        return self.upsert_entry(project_dir, branch, {"status": status})
+
+    def update_git_metrics(self, project_dir: str, branch: str, **kwargs: Any) -> bool:
+        """
+        Update git metrics on a WIP entry.
+
+        Args:
+            **kwargs: Metric fields to update (commit_count, files_changed, etc.)
+
+        Returns:
+            True if successful, False on error.
+        """
+        key = self._make_key(project_dir, branch)
+
+        def _update(registry: dict) -> Optional[dict]:
+            entries = registry.get("entries", {})
+            if key not in entries:
+                return None  # No entry to update
+            metrics = entries[key].setdefault("git_metrics", {})
+            for field, value in kwargs.items():
+                metrics[field] = value
+            entries[key]["updated_at"] = time.time()
+            return registry
+
+        return self._client.update(_update)
+
+    def increment_time(self, project_dir: str, branch: str, seconds: float) -> bool:
+        """
+        Add elapsed time to a WIP entry.
+
+        Args:
+            seconds: Time to add in seconds
+
+        Returns:
+            True if successful, False on error.
+        """
+        key = self._make_key(project_dir, branch)
+
+        def _update(registry: dict) -> Optional[dict]:
+            entries = registry.get("entries", {})
+            if key not in entries:
+                return None
+            entries[key]["total_time_seconds"] = (
+                entries[key].get("total_time_seconds", 0) + seconds
+            )
+            entries[key]["updated_at"] = time.time()
+            return registry
+
+        return self._client.update(_update)
+
+    def check_merged_branches(self, project_dir: str) -> list[str]:
+        """
+        Detect branches merged into main and auto-mark as done.
+
+        Returns:
+            List of branch names that were marked done.
+        """
+        logger = get_logger(base_context={"component": "WipTracker"})
+        marked = []
+
+        # Get merged branches from git
+        exit_code, stdout, _ = run_git("git branch --merged main", cwd=project_dir)
+        if exit_code != 0:
+            # Try 'master' as fallback
+            exit_code, stdout, _ = run_git(
+                "git branch --merged master", cwd=project_dir
+            )
+        if exit_code != 0:
+            return []
+
+        merged = set()
+        for line in stdout.splitlines():
+            branch = line.strip().lstrip("* ")
+            if branch and branch not in ("main", "master", "develop"):
+                merged.add(branch)
+
+        if not merged:
+            return []
+
+        # Check WIP entries and mark merged ones as done
+        registry = self._client.read()
+        entries = registry.get("entries", {})
+        updated = False
+
+        for key, entry in entries.items():
+            if (
+                entry.get("project_dir") == project_dir
+                and entry.get("branch") in merged
+                and entry.get("status") != "done"
+            ):
+                entry["status"] = "done"
+                entry["updated_at"] = time.time()
+                marked.append(entry["branch"])
+                updated = True
+                logger.info("Auto-marked merged branch as done", branch=entry["branch"])
+
+        if updated:
+            self._client.write(registry)
+
+        return marked
+
+    def list_entries(
+        self,
+        status: Optional[str] = None,
+        project: Optional[str] = None,
+    ) -> list[dict]:
+        """
+        List WIP entries with optional filtering.
+
+        Args:
+            status: Filter by status (wip, done, paused, todo)
+            project: Filter by project directory path
+
+        Returns:
+            List of matching entry dicts.
+        """
+        registry = self._client.read()
+        entries = registry.get("entries", {})
+
+        results = []
+        for entry in entries.values():
+            if status and entry.get("status") != status:
+                continue
+            if project and entry.get("project_dir") != project:
+                continue
+            results.append(entry)
+
+        # Sort by updated_at descending (most recent first)
+        results.sort(key=lambda e: e.get("updated_at", 0), reverse=True)
+        return results
+
+    def clean_done(self) -> int:
+        """
+        Remove all entries with status 'done'.
+
+        Returns:
+            Count of removed entries.
+        """
+        registry = self._client.read()
+        count = sum(
+            1 for e in registry.get("entries", {}).values()
+            if e.get("status") == "done"
+        )
+
+        if count == 0:
+            return 0
+
+        def _update(reg: dict) -> Optional[dict]:
+            entries = reg.get("entries", {})
+            to_remove = [
+                key for key, entry in entries.items()
+                if entry.get("status") == "done"
+            ]
+            if not to_remove:
+                return None
+            for key in to_remove:
+                del entries[key]
+            return reg
+
+        self._client.update(_update)
+        return count

--- a/hooks/requirements-cli.py
+++ b/hooks/requirements-cli.py
@@ -3622,6 +3622,11 @@ def _cmd_wip_clean(args) -> int:
     from wip_tracker import WipTracker
 
     tracker = WipTracker()
+
+    # Collect done entries before cleaning (for --delete-branches)
+    delete_branches = getattr(args, 'delete_branches', False)
+    done_entries = tracker.list_entries(status="done") if delete_branches else []
+
     count = tracker.clean_done()
 
     if count == 0:
@@ -3629,9 +3634,8 @@ def _cmd_wip_clean(args) -> int:
     else:
         out(success(f"Removed {count} done entries."))
 
-    # Optionally delete local branches
-    if getattr(args, 'delete_branches', False):
-        done_entries = tracker.list_entries(status="done")
+    # Optionally delete local branches (collected before clean)
+    if delete_branches:
         for entry in done_entries:
             branch = entry.get("branch", "")
             proj = entry.get("project_dir", "")

--- a/hooks/requirements-cli.py
+++ b/hooks/requirements-cli.py
@@ -3451,6 +3451,226 @@ def _cmd_messages_list(args) -> int:
     return 0
 
 
+def _format_duration(seconds: float) -> str:
+    """Format seconds into human-readable duration."""
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    minutes = int(seconds // 60)
+    if minutes < 60:
+        return f"{minutes}m"
+    hours = minutes // 60
+    remaining_min = minutes % 60
+    if remaining_min:
+        return f"{hours}h {remaining_min}m"
+    return f"{hours}h"
+
+
+def cmd_wip(args) -> int:
+    """
+    Manage WIP project tracking.
+
+    Subcommands:
+        list    - Show WIP dashboard
+        status  - Show current branch details
+        set     - Set branch status
+        clean   - Remove done entries
+        summary - Set/update summary
+    """
+    subcommand = args.wip_command or 'list'
+
+    if subcommand == 'list':
+        return _cmd_wip_list(args)
+    elif subcommand == 'status':
+        return _cmd_wip_status(args)
+    elif subcommand == 'set':
+        return _cmd_wip_set(args)
+    elif subcommand == 'clean':
+        return _cmd_wip_clean(args)
+    elif subcommand == 'summary':
+        return _cmd_wip_summary(args)
+    else:
+        out(error(f"Unknown subcommand: {subcommand}"), file=sys.stderr)
+        return 1
+
+
+def _cmd_wip_list(args) -> int:
+    """Show WIP dashboard across all projects."""
+    from wip_tracker import WipTracker
+
+    tracker = WipTracker()
+    status_filter = getattr(args, 'status', None)
+    project_filter = getattr(args, 'project', None)
+    entries = tracker.list_entries(status=status_filter, project=project_filter)
+
+    # Filter out 'done' by default unless --all flag
+    show_all = getattr(args, 'all', False)
+    if not show_all:
+        entries = [e for e in entries if e.get("status") != "done"]
+
+    if not entries:
+        out(info("No WIP branches tracked."))
+        out(hint("WIP entries are created automatically when wip_tracking is enabled."))
+        return 0
+
+    out(header("WIP Projects Dashboard"))
+    out(dim("─" * 80))
+
+    # Table header
+    out(f"  {'Project':<18} {'Branch':<22} {'Status':<8} {'Summary':<24} {'Commits':<8} {'Time'}")
+    out(f"  {'─'*17} {'─'*21} {'─'*7} {'─'*23} {'─'*7} {'─'*6}")
+
+    status_counts: dict[str, int] = {}
+    for e in entries:
+        proj_name = Path(e["project_dir"]).name[:17]
+        branch = e.get("branch", "?")[:21]
+        status = e.get("status", "?").upper()
+        summary = e.get("summary", "")[:23]
+        commits = e.get("git_metrics", {}).get("commit_count", 0)
+        total_time = e.get("total_time_seconds", 0)
+
+        status_counts[status] = status_counts.get(status, 0) + 1
+        out(f"  {proj_name:<18} {branch:<22} {status:<8} {summary:<24} {commits:<8} {_format_duration(total_time)}")
+
+    out(dim("─" * 80))
+    parts = [f"{c} {s}" for s, c in sorted(status_counts.items())]
+    out(f"{len(entries)} branch(es) tracked ({', '.join(parts)})")
+    return 0
+
+
+def _cmd_wip_status(args) -> int:
+    """Show details for current branch."""
+    from wip_tracker import WipTracker
+
+    project_dir = get_project_dir()
+    if not is_git_repo(project_dir):
+        out(error("Not in a git repository"), file=sys.stderr)
+        return 1
+
+    branch = get_current_branch(project_dir)
+    if not branch:
+        out(error("Cannot determine current branch"), file=sys.stderr)
+        return 1
+
+    tracker = WipTracker()
+    entry = tracker.get_entry(project_dir, branch)
+
+    if not entry:
+        out(info(f"No WIP entry for branch '{branch}'."))
+        return 0
+
+    out(header(f"WIP: {branch}"))
+    out()
+    out(f"  Status:     {bold(entry.get('status', '?').upper())}")
+    out(f"  Summary:    {entry.get('summary', '(none)')}")
+    out(f"  Project:    {entry.get('project_dir', '?')}")
+
+    issue = entry.get("github_issue", "")
+    if issue:
+        out(f"  Issue:      {issue}")
+
+    plan = entry.get("plan_path", "")
+    if plan:
+        out(f"  Plan:       {plan}")
+
+    out()
+    metrics = entry.get("git_metrics", {})
+    out(f"  Commits:    {metrics.get('commit_count', 0)}")
+    out(f"  Files:      {metrics.get('files_changed', 0)}")
+    out(f"  Added:      +{metrics.get('lines_added', 0)}")
+    out(f"  Removed:    -{metrics.get('lines_removed', 0)}")
+    out(f"  Pushed:     {'Yes' if metrics.get('pushed') else 'No'}")
+    pr = metrics.get("pr_url")
+    if pr:
+        out(f"  PR:         {pr}")
+
+    out()
+    total_time = entry.get("total_time_seconds", 0)
+    out(f"  Total Time: {_format_duration(total_time)}")
+    sessions = entry.get("session_history", [])
+    out(f"  Sessions:   {len(sessions)}")
+
+    return 0
+
+
+def _cmd_wip_set(args) -> int:
+    """Set WIP status for current branch."""
+    from wip_tracker import WipTracker, VALID_STATUSES
+
+    project_dir = get_project_dir()
+    if not is_git_repo(project_dir):
+        out(error("Not in a git repository"), file=sys.stderr)
+        return 1
+
+    branch = get_current_branch(project_dir)
+    if not branch:
+        out(error("Cannot determine current branch"), file=sys.stderr)
+        return 1
+
+    new_status = args.status
+    if new_status not in VALID_STATUSES:
+        out(error(f"Invalid status '{new_status}'. Must be one of: {', '.join(sorted(VALID_STATUSES))}"), file=sys.stderr)
+        return 1
+
+    tracker = WipTracker()
+    tracker.set_status(project_dir, branch, new_status)
+    out(success(f"Set '{branch}' status to {new_status.upper()}"))
+    return 0
+
+
+def _cmd_wip_clean(args) -> int:
+    """Remove done entries."""
+    from wip_tracker import WipTracker
+
+    tracker = WipTracker()
+    count = tracker.clean_done()
+
+    if count == 0:
+        out(info("No done entries to clean."))
+    else:
+        out(success(f"Removed {count} done entries."))
+
+    # Optionally delete local branches
+    if getattr(args, 'delete_branches', False):
+        done_entries = tracker.list_entries(status="done")
+        for entry in done_entries:
+            branch = entry.get("branch", "")
+            proj = entry.get("project_dir", "")
+            if branch and proj:
+                from git_utils import run_git
+                exit_code, _, stderr = run_git(f"git branch -d {branch}", cwd=proj)
+                if exit_code == 0:
+                    out(success(f"  Deleted branch: {branch}"))
+                else:
+                    out(warning(f"  Could not delete {branch}: {stderr}"))
+
+    return 0
+
+
+def _cmd_wip_summary(args) -> int:
+    """Set/update summary for current branch."""
+    from wip_tracker import WipTracker
+
+    project_dir = get_project_dir()
+    if not is_git_repo(project_dir):
+        out(error("Not in a git repository"), file=sys.stderr)
+        return 1
+
+    branch = get_current_branch(project_dir)
+    if not branch:
+        out(error("Cannot determine current branch"), file=sys.stderr)
+        return 1
+
+    text = " ".join(args.text)
+    if not text:
+        out(error("Please provide summary text"), file=sys.stderr)
+        return 1
+
+    tracker = WipTracker()
+    tracker.upsert_entry(project_dir, branch, {"summary": text})
+    out(success(f"Updated summary for '{branch}'"))
+    return 0
+
+
 def main() -> int:
     """
     CLI entry point.
@@ -3624,6 +3844,34 @@ Environment Variables:
     upgrade_apply.add_argument('--dry-run', action='store_true', help='Show what would be added without writing')
     upgrade_apply.add_argument('--yes', '-y', action='store_true', help='Skip confirmation prompt')
 
+    # wip
+    wip_parser = subparsers.add_parser('wip', help='Manage WIP project tracking')
+    wip_subparsers = wip_parser.add_subparsers(dest='wip_command', help='WIP subcommand')
+
+    # wip list
+    wip_list = wip_subparsers.add_parser('list', help='Show WIP dashboard')
+    wip_list.add_argument('--status', '-s', choices=['wip', 'done', 'paused', 'todo'],
+                          help='Filter by status')
+    wip_list.add_argument('--project', '-p', help='Filter by project directory')
+    wip_list.add_argument('--all', '-a', action='store_true', help='Include done entries')
+
+    # wip status
+    wip_subparsers.add_parser('status', help='Show current branch details')
+
+    # wip set
+    wip_set = wip_subparsers.add_parser('set', help='Set branch status')
+    wip_set.add_argument('status', choices=['wip', 'done', 'paused', 'todo'],
+                         help='New status')
+
+    # wip clean
+    wip_clean = wip_subparsers.add_parser('clean', help='Remove done entries')
+    wip_clean.add_argument('--delete-branches', action='store_true',
+                           help='Also delete local git branches')
+
+    # wip summary
+    wip_summary = wip_subparsers.add_parser('summary', help='Set/update summary')
+    wip_summary.add_argument('text', nargs='+', help='Summary text')
+
     # messages
     messages_parser = subparsers.add_parser('messages', help='Manage externalized message files')
     messages_subparsers = messages_parser.add_subparsers(dest='messages_command', help='Messages subcommand')
@@ -3659,6 +3907,7 @@ Environment Variables:
         'learning': cmd_learning,
         'upgrade': cmd_upgrade,
         'messages': cmd_messages,
+        'wip': cmd_wip,
     }
 
     return commands[args.command](args)

--- a/hooks/test_requirements.py
+++ b/hooks/test_requirements.py
@@ -9572,6 +9572,110 @@ def test_wip_tracker_module(runner: TestRunner):
         runner.test("add_session creates entry if missing",
                    entry is not None and entry["session_id"] == "sess-1")
 
+        # Test 20: record_commit atomically increments
+        tracker3 = WipTracker(wip_path=Path(tmpdir) / "wip3.json")
+        tracker3.upsert_entry("/proj", "feat/x", {"status": "wip"})
+        tracker3.record_commit("/proj", "feat/x", commit_hash="abc123",
+                               files_changed=3, lines_added=10, lines_removed=2)
+        entry = tracker3.get_entry("/proj", "feat/x")
+        runner.test("record_commit increments count",
+                   entry["git_metrics"]["commit_count"] == 1)
+        runner.test("record_commit sets hash",
+                   entry["git_metrics"]["last_commit_hash"] == "abc123")
+        tracker3.record_commit("/proj", "feat/x", commit_hash="def456")
+        entry = tracker3.get_entry("/proj", "feat/x")
+        runner.test("record_commit increments atomically",
+                   entry["git_metrics"]["commit_count"] == 2)
+
+        # Test 21: record_commit returns True for missing entry
+        result = tracker3.record_commit("/nonexistent", "b", commit_hash="x")
+        runner.test("record_commit returns True for missing", result is True)
+
+
+def test_handle_git_events(runner: TestRunner):
+    """Test handle-git-events.py PostToolUse hook behavior."""
+    print("\n📦 Testing GitEvents hook...")
+
+    hook_path = Path(__file__).parent / "handle-git-events.py"
+
+    if not hook_path.exists():
+        runner.test("GitEvents hook exists", False, "Hook file not found")
+        return
+
+    def run_hook(input_data, cwd, env=None):
+        return subprocess.run(
+            ["python3", str(hook_path)],
+            input=json.dumps(input_data),
+            cwd=cwd, capture_output=True, text=True,
+            env={**os.environ, **(env or {})}
+        )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Initialize git repo with feature branch
+        subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True)
+        subprocess.run(["git", "checkout", "-b", "feature/test"], cwd=tmpdir, capture_output=True)
+
+        base_input = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "git commit -m 'test'"},
+            "tool_result": {"stdout": "", "stderr": ""},
+            "session_id": "gitevents-test"
+        }
+
+        # Test 1: Skips non-Bash tool
+        non_bash_input = {**base_input, "tool_name": "Edit"}
+        result = run_hook(non_bash_input, tmpdir)
+        runner.test("Skips non-Bash tool", result.returncode == 0)
+
+        # Test 2: Skips when no config exists (WIP not enabled)
+        result = run_hook(base_input, tmpdir)
+        runner.test("Skips when WIP not enabled",
+                   result.returncode == 0 and result.stdout.strip() == "")
+
+        # Test 3: Skips empty command
+        empty_cmd_input = {**base_input, "tool_input": {}}
+        result = run_hook(empty_cmd_input, tmpdir)
+        runner.test("Skips empty command", result.returncode == 0)
+
+        # Test 4: Skips excluded branches
+        subprocess.run(["git", "checkout", "-b", "main"], cwd=tmpdir, capture_output=True)
+        os.makedirs(f"{tmpdir}/.claude")
+        config = {
+            "version": "1.0",
+            "enabled": True,
+            "inherit": False,
+            "requirements": {},
+            "hooks": {"wip_tracking": {"enabled": True}}
+        }
+        with open(f"{tmpdir}/.claude/requirements.yaml", 'w') as f:
+            json.dump(config, f)
+        result = run_hook(base_input, tmpdir)
+        runner.test("Skips excluded branches (main)",
+                   result.returncode == 0 and result.stdout.strip() == "")
+
+        # Test 5: Handles git push command pattern
+        subprocess.run(["git", "checkout", "feature/test"], cwd=tmpdir, capture_output=True)
+        push_input = {**base_input, "tool_input": {"command": "git push -u origin feature/test"}}
+        result = run_hook(push_input, tmpdir)
+        runner.test("Handles git push without error", result.returncode == 0)
+
+        # Test 6: Handles gh pr create command pattern
+        pr_input = {
+            **base_input,
+            "tool_input": {"command": "gh pr create --title 'test'"},
+            "tool_result": {"stdout": "https://github.com/user/repo/pull/42\n"}
+        }
+        result = run_hook(pr_input, tmpdir)
+        runner.test("Handles gh pr create without error", result.returncode == 0)
+
+        # Test 7: Handles malformed JSON gracefully
+        result = subprocess.run(
+            ["python3", str(hook_path)],
+            input="not json",
+            cwd=tmpdir, capture_output=True, text=True
+        )
+        runner.test("Handles malformed JSON", result.returncode == 0)
+
 
 def main():
     """Run all tests."""
@@ -9753,6 +9857,9 @@ def main():
 
     # WIP tracker module tests
     test_wip_tracker_module(runner)
+
+    # Git events hook tests
+    test_handle_git_events(runner)
 
     return runner.summary()
 

--- a/hooks/test_requirements.py
+++ b/hooks/test_requirements.py
@@ -9439,6 +9439,140 @@ def test_plan_enter_hook(runner: TestRunner):
                    f"Got: {val}")
 
 
+def test_wip_tracker_module(runner: TestRunner):
+    """Test WIP tracker core library."""
+    print("\n📦 Testing WIP tracker module...")
+    from wip_tracker import WipTracker, VALID_STATUSES, _new_entry
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        wip_path = Path(tmpdir) / "wip_projects.json"
+        tracker = WipTracker(wip_path=wip_path)
+
+        project = "/tmp/test-project"
+        branch = "feature/auth"
+
+        # Test 1: _make_key creates composite key
+        key = tracker._make_key(project, branch)
+        runner.test("_make_key creates composite key",
+                   key == f"{project}::{branch}",
+                   f"Got: {key}")
+
+        # Test 2: get_entry returns None for missing entry
+        entry = tracker.get_entry(project, branch)
+        runner.test("get_entry returns None for missing", entry is None)
+
+        # Test 3: upsert_entry creates new entry
+        result = tracker.upsert_entry(project, branch, {"summary": "OAuth2 flow"})
+        runner.test("upsert_entry returns True", result is True)
+        entry = tracker.get_entry(project, branch)
+        runner.test("upsert_entry creates entry",
+                   entry is not None and entry["summary"] == "OAuth2 flow",
+                   f"Got: {entry}")
+
+        # Test 4: upsert_entry updates existing entry
+        tracker.upsert_entry(project, branch, {"summary": "Updated OAuth2"})
+        entry = tracker.get_entry(project, branch)
+        runner.test("upsert_entry updates existing",
+                   entry["summary"] == "Updated OAuth2")
+
+        # Test 5: add_session registers session
+        tracker.add_session(project, branch, "session-1")
+        entry = tracker.get_entry(project, branch)
+        runner.test("add_session sets session_id",
+                   entry["session_id"] == "session-1")
+        runner.test("add_session adds to history",
+                   "session-1" in entry["session_history"])
+
+        # Test 6: add_session is idempotent for same session
+        tracker.add_session(project, branch, "session-1")
+        entry = tracker.get_entry(project, branch)
+        runner.test("add_session idempotent",
+                   entry["session_history"].count("session-1") == 1)
+
+        # Test 7: add_session appends new sessions
+        tracker.add_session(project, branch, "session-2")
+        entry = tracker.get_entry(project, branch)
+        runner.test("add_session appends new session",
+                   len(entry["session_history"]) == 2 and entry["session_id"] == "session-2")
+
+        # Test 8: set_status validates status
+        result = tracker.set_status(project, branch, "invalid")
+        runner.test("set_status rejects invalid status", result is False)
+
+        # Test 9: set_status updates valid status
+        tracker.set_status(project, branch, "paused")
+        entry = tracker.get_entry(project, branch)
+        runner.test("set_status updates to paused",
+                   entry["status"] == "paused")
+
+        # Test 10: VALID_STATUSES contains expected values
+        runner.test("VALID_STATUSES has 4 statuses",
+                   VALID_STATUSES == {"wip", "done", "paused", "todo"})
+
+        # Test 11: update_git_metrics sets metrics
+        tracker.update_git_metrics(project, branch, commit_count=5, pushed=True)
+        entry = tracker.get_entry(project, branch)
+        runner.test("update_git_metrics sets fields",
+                   entry["git_metrics"]["commit_count"] == 5 and
+                   entry["git_metrics"]["pushed"] is True)
+
+        # Test 12: update_git_metrics returns True for missing entry
+        result = tracker.update_git_metrics("/nonexistent", "main", commit_count=1)
+        runner.test("update_git_metrics returns True for missing entry",
+                   result is True,
+                   f"Got: {result}")
+
+        # Test 13: increment_time adds time
+        tracker.increment_time(project, branch, 3600)
+        entry = tracker.get_entry(project, branch)
+        runner.test("increment_time adds seconds",
+                   entry["total_time_seconds"] == 3600)
+        tracker.increment_time(project, branch, 1800)
+        entry = tracker.get_entry(project, branch)
+        runner.test("increment_time accumulates",
+                   entry["total_time_seconds"] == 5400)
+
+        # Test 14: list_entries returns all entries
+        tracker.upsert_entry("/tmp/other", "fix/bug", {"status": "wip", "summary": "Bug fix"})
+        all_entries = tracker.list_entries()
+        runner.test("list_entries returns all",
+                   len(all_entries) == 2)
+
+        # Test 15: list_entries filters by status
+        wip_entries = tracker.list_entries(status="wip")
+        runner.test("list_entries filters by status",
+                   len(wip_entries) == 1 and wip_entries[0]["branch"] == "fix/bug")
+
+        # Test 16: list_entries filters by project
+        project_entries = tracker.list_entries(project=project)
+        runner.test("list_entries filters by project",
+                   len(project_entries) == 1 and project_entries[0]["branch"] == branch)
+
+        # Test 17: clean_done removes done entries
+        tracker.set_status(project, branch, "done")
+        count = tracker.clean_done()
+        runner.test("clean_done removes done entries", count == 1)
+        entry = tracker.get_entry(project, branch)
+        runner.test("clean_done entry is gone", entry is None)
+        remaining = tracker.list_entries()
+        runner.test("clean_done preserves non-done", len(remaining) == 1)
+
+        # Test 18: _new_entry has correct structure
+        new = _new_entry("/test", "branch")
+        runner.test("_new_entry has required fields",
+                   all(k in new for k in ["project_dir", "branch", "status",
+                                           "summary", "git_metrics", "total_time_seconds"]))
+        runner.test("_new_entry default status is wip",
+                   new["status"] == "wip")
+
+        # Test 19: add_session creates entry if not exists
+        tracker2 = WipTracker(wip_path=Path(tmpdir) / "wip2.json")
+        tracker2.add_session("/new/project", "feature/new", "sess-1")
+        entry = tracker2.get_entry("/new/project", "feature/new")
+        runner.test("add_session creates entry if missing",
+                   entry is not None and entry["session_id"] == "sess-1")
+
+
 def main():
     """Run all tests."""
     print("🧪 Requirements Framework Test Suite")
@@ -9616,6 +9750,9 @@ def main():
 
     # Plan enter hook tests
     test_plan_enter_hook(runner)
+
+    # WIP tracker module tests
+    test_wip_tracker_module(runner)
 
     return runner.summary()
 

--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,7 @@ cp -v "$REPO_DIR/hooks/handle-plan-enter.py" "$HOME/.claude/hooks/"
 cp -v "$REPO_DIR/hooks/ruff_check.py" "$HOME/.claude/hooks/"
 cp -v "$REPO_DIR/hooks/handle-teammate-idle.py" "$HOME/.claude/hooks/"
 cp -v "$REPO_DIR/hooks/handle-task-completed.py" "$HOME/.claude/hooks/"
+cp -v "$REPO_DIR/hooks/handle-git-events.py" "$HOME/.claude/hooks/"
 
 # Copy library files
 echo "📚 Copying library files to ~/.claude/hooks/lib/..."
@@ -55,6 +56,7 @@ chmod +x "$HOME/.claude/hooks/handle-plan-enter.py"
 chmod +x "$HOME/.claude/hooks/ruff_check.py"
 chmod +x "$HOME/.claude/hooks/handle-teammate-idle.py"
 chmod +x "$HOME/.claude/hooks/handle-task-completed.py"
+chmod +x "$HOME/.claude/hooks/handle-git-events.py"
 
 # Configure Codex requirement interactively
 configure_codex_requirement() {
@@ -312,7 +314,8 @@ REQUIRED_HOOKS = {
             {"type": "command", "command": "~/.claude/hooks/auto-satisfy-skills.py"},
             {"type": "command", "command": "~/.claude/hooks/clear-single-use.py"},
             {"type": "command", "command": "~/.claude/hooks/handle-plan-exit.py"},
-            {"type": "command", "command": "~/.claude/hooks/handle-plan-enter.py"}
+            {"type": "command", "command": "~/.claude/hooks/handle-plan-enter.py"},
+            {"type": "command", "command": "~/.claude/hooks/handle-git-events.py"}
         ]
     }],
     "SessionStart": [{

--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Claude Code Requirements Framework - Complete development lifecycle from ideation to completion. Enforces workflow requirements through hooks, guides process with 19 development skills (brainstorming, TDD, debugging, verification), and provides comprehensive code review agents.",
   "author": {
     "name": "Harm"


### PR DESCRIPTION
## Summary

- Add `WipTracker` core library using `RegistryClient` for atomic operations on `~/.claude/wip_projects.json`
- Add `handle-git-events.py` PostToolUse hook to auto-track git commits, pushes, and PR creation
- Integrate WIP tracking into session-start (context injection + merge detection), plan-exit (auto-create entries), stop (status prompt), and session-end (time tracking) hooks
- Add `req wip` CLI commands: `list`, `status`, `set`, `clean`, `summary`
- Register `wip_tracking` in config defaults (disabled by default) and feature catalog
- Bump plugin version to 2.7.0

## Test Plan

- [x] 1127/1127 tests pass (36 new tests added)
- [x] WipTracker core: 29 tests covering all methods including atomic `record_commit`
- [x] handle-git-events hook: 7 tests covering early-return paths and command patterns
- [x] CLI smoke test: `req wip list`, `req wip set`, `req wip summary`, `req wip clean` verified manually
- [x] Deep review completed: 3 CRITICAL issues found and fixed (NameError, dead code, missing tests)

Closes #83