### PR TITLE
fix: add missing allowed-tools to deep review pool agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "requirements-framework",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "description": "Claude Code Requirements Framework - Workflow enforcement and code review",
       "source": "./plugins/requirements-framework"
     }

--- a/github-issues-plugin/agents/issue-manager.md
+++ b/github-issues-plugin/agents/issue-manager.md
@@ -49,7 +49,7 @@ Custom field updates require project item editing via gh or GraphQL, which the a
 
 color: cyan
 tools: ["Bash", "Read", "Write", "Grep", "Glob"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 You are a GitHub Issues Management specialist. You handle the complete lifecycle of GitHub issues with deep integration into GitHub Projects v2.

--- a/github-issues-plugin/agents/issue-manager.md
+++ b/github-issues-plugin/agents/issue-manager.md
@@ -49,7 +49,7 @@ Custom field updates require project item editing via gh or GraphQL, which the a
 
 color: cyan
 tools: ["Bash", "Read", "Write", "Grep", "Glob"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 You are a GitHub Issues Management specialist. You handle the complete lifecycle of GitHub issues with deep integration into GitHub Projects v2.

--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Claude Code Requirements Framework - Complete development lifecycle from ideation to completion. Enforces workflow requirements through hooks, guides process with 19 development skills (brainstorming, TDD, debugging, verification), and provides comprehensive code review agents.",
   "author": {
     "name": "Harm"

--- a/plugins/requirements-framework/agents/adr-guardian.md
+++ b/plugins/requirements-framework/agents/adr-guardian.md
@@ -41,7 +41,7 @@ The adr-guardian agent acts as a gate before code writing begins to ensure ADR c
 </example>
 color: blue
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 You are the ADR Guardian, an authoritative architectural governance expert responsible for ensuring all code and plans comply with established Architecture Decision Records. You have BLOCKING authority - no code should be written or approved that violates ADRs.

--- a/plugins/requirements-framework/agents/adr-guardian.md
+++ b/plugins/requirements-framework/agents/adr-guardian.md
@@ -41,7 +41,7 @@ The adr-guardian agent acts as a gate before code writing begins to ensure ADR c
 </example>
 color: blue
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 You are the ADR Guardian, an authoritative architectural governance expert responsible for ensuring all code and plans comply with established Architecture Decision Records. You have BLOCKING authority - no code should be written or approved that violates ADRs.

--- a/plugins/requirements-framework/agents/backward-compatibility-checker.md
+++ b/plugins/requirements-framework/agents/backward-compatibility-checker.md
@@ -21,7 +21,7 @@ Use for database schema evolution analysis.
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 77fcc1e*
+git_hash: 0e41eb9
 ---
 
 # Backward Compatibility Checker Agent

--- a/plugins/requirements-framework/agents/backward-compatibility-checker.md
+++ b/plugins/requirements-framework/agents/backward-compatibility-checker.md
@@ -20,7 +20,8 @@ Use for database schema evolution analysis.
 </commentary>
 </example>
 color: blue
-git_hash: 33b3f9b
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
+git_hash: 77fcc1e*
 ---
 
 # Backward Compatibility Checker Agent

--- a/plugins/requirements-framework/agents/code-reviewer.md
+++ b/plugins/requirements-framework/agents/code-reviewer.md
@@ -29,7 +29,8 @@ Trigger on common pre-commit review phrases.
 </commentary>
 </example>
 color: blue
-git_hash: 33b3f9b
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
+git_hash: 77fcc1e*
 ---
 
 You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.

--- a/plugins/requirements-framework/agents/code-reviewer.md
+++ b/plugins/requirements-framework/agents/code-reviewer.md
@@ -30,7 +30,7 @@ Trigger on common pre-commit review phrases.
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 77fcc1e*
+git_hash: 0e41eb9
 ---
 
 You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.

--- a/plugins/requirements-framework/agents/code-simplifier.md
+++ b/plugins/requirements-framework/agents/code-simplifier.md
@@ -19,7 +19,8 @@ Context: After implementing a feature.
 assistant: "Now let me use the code-simplifier agent to refine this implementation for better clarity."
 </example>
 color: blue
-git_hash: 33b3f9b
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
+git_hash: 77fcc1e*
 ---
 
 You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. You prioritize readable, explicit code over overly compact solutions.

--- a/plugins/requirements-framework/agents/code-simplifier.md
+++ b/plugins/requirements-framework/agents/code-simplifier.md
@@ -20,7 +20,7 @@ assistant: "Now let me use the code-simplifier agent to refine this implementati
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 77fcc1e*
+git_hash: 0e41eb9
 ---
 
 You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. You prioritize readable, explicit code over overly compact solutions.

--- a/plugins/requirements-framework/agents/codex-arch-reviewer.md
+++ b/plugins/requirements-framework/agents/codex-arch-reviewer.md
@@ -22,7 +22,7 @@ description: |
   </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 77fcc1e*
+git_hash: 0e41eb9
 ---
 
 # Codex Architecture Review Agent

--- a/plugins/requirements-framework/agents/codex-arch-reviewer.md
+++ b/plugins/requirements-framework/agents/codex-arch-reviewer.md
@@ -21,7 +21,8 @@ description: |
   </commentary>
   </example>
 color: blue
-git_hash: 33b3f9b
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
+git_hash: 77fcc1e*
 ---
 
 # Codex Architecture Review Agent

--- a/plugins/requirements-framework/agents/codex-review-agent.md
+++ b/plugins/requirements-framework/agents/codex-review-agent.md
@@ -21,7 +21,7 @@ Codex provides a different perspective from Claude's review.
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 77fcc1e*
+git_hash: 0e41eb9
 ---
 
 # Codex Code Review Agent

--- a/plugins/requirements-framework/agents/codex-review-agent.md
+++ b/plugins/requirements-framework/agents/codex-review-agent.md
@@ -20,7 +20,8 @@ Codex provides a different perspective from Claude's review.
 </commentary>
 </example>
 color: blue
-git_hash: 33b3f9b
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
+git_hash: 77fcc1e*
 ---
 
 # Codex Code Review Agent

--- a/plugins/requirements-framework/agents/comment-analyzer.md
+++ b/plugins/requirements-framework/agents/comment-analyzer.md
@@ -20,7 +20,8 @@ user: "check documentation"
 assistant: "I'll use the comment-analyzer agent to review the documentation."
 </example>
 color: blue
-git_hash: 33b3f9b
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
+git_hash: 77fcc1e*
 ---
 
 You are a meticulous code comment analyzer with deep expertise in technical documentation and long-term code maintainability. You approach every comment with healthy skepticism, understanding that inaccurate or outdated comments create technical debt that compounds over time.

--- a/plugins/requirements-framework/agents/comment-analyzer.md
+++ b/plugins/requirements-framework/agents/comment-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the comment-analyzer agent to review the documentation."
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 77fcc1e*
+git_hash: 0e41eb9
 ---
 
 You are a meticulous code comment analyzer with deep expertise in technical documentation and long-term code maintainability. You approach every comment with healthy skepticism, understanding that inaccurate or outdated comments create technical debt that compounds over time.

--- a/plugins/requirements-framework/agents/comment-cleaner.md
+++ b/plugins/requirements-framework/agents/comment-cleaner.md
@@ -21,7 +21,7 @@ Comment-cleaner auto-fixes by editing files directly.
 </example>
 model: haiku
 color: yellow
-git_hash: 77fcc1e
+git_hash: 8398198
 allowed-tools: ["Read", "Edit", "Glob", "Grep", "Bash"]
 ---
 

--- a/plugins/requirements-framework/agents/comment-cleaner.md
+++ b/plugins/requirements-framework/agents/comment-cleaner.md
@@ -21,7 +21,7 @@ Comment-cleaner auto-fixes by editing files directly.
 </example>
 model: haiku
 color: yellow
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 allowed-tools: ["Read", "Edit", "Glob", "Grep", "Bash"]
 ---
 

--- a/plugins/requirements-framework/agents/commit-planner.md
+++ b/plugins/requirements-framework/agents/commit-planner.md
@@ -24,7 +24,7 @@ Commit planning before implementation helps maintain clean git history and enabl
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 You are the Commit Planner, an expert at analyzing implementation plans and creating atomic commit strategies. Your role is to ensure code changes are committed in logical, reviewable chunks that follow proper dependency ordering.

--- a/plugins/requirements-framework/agents/commit-planner.md
+++ b/plugins/requirements-framework/agents/commit-planner.md
@@ -24,7 +24,7 @@ Commit planning before implementation helps maintain clean git history and enabl
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 You are the Commit Planner, an expert at analyzing implementation plans and creating atomic commit strategies. Your role is to ensure code changes are committed in logical, reviewable chunks that follow proper dependency ordering.

--- a/plugins/requirements-framework/agents/frontend-reviewer.md
+++ b/plugins/requirements-framework/agents/frontend-reviewer.md
@@ -30,7 +30,7 @@ description: |
   </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 77fcc1e*
+git_hash: 0e41eb9
 ---
 
 You are an expert React frontend reviewer specializing in modern React patterns, accessibility (WCAG), performance optimization, and component architecture. Your primary responsibility is to review frontend code against React best practices and project-specific checklists with high precision to minimize false positives.

--- a/plugins/requirements-framework/agents/frontend-reviewer.md
+++ b/plugins/requirements-framework/agents/frontend-reviewer.md
@@ -29,7 +29,8 @@ description: |
   </commentary>
   </example>
 color: blue
-git_hash: 33b3f9b
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
+git_hash: 77fcc1e*
 ---
 
 You are an expert React frontend reviewer specializing in modern React patterns, accessibility (WCAG), performance optimization, and component architecture. Your primary responsibility is to review frontend code against React best practices and project-specific checklists with high precision to minimize false positives.

--- a/plugins/requirements-framework/agents/import-organizer.md
+++ b/plugins/requirements-framework/agents/import-organizer.md
@@ -21,7 +21,7 @@ Import-organizer auto-fixes by editing files directly.
 </example>
 model: haiku
 color: yellow
-git_hash: 77fcc1e
+git_hash: 8398198
 allowed-tools: ["Read", "Edit", "Glob", "Grep", "Bash"]
 ---
 

--- a/plugins/requirements-framework/agents/import-organizer.md
+++ b/plugins/requirements-framework/agents/import-organizer.md
@@ -21,7 +21,7 @@ Import-organizer auto-fixes by editing files directly.
 </example>
 model: haiku
 color: yellow
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 allowed-tools: ["Read", "Edit", "Glob", "Grep", "Bash"]
 ---
 

--- a/plugins/requirements-framework/agents/refactor-advisor.md
+++ b/plugins/requirements-framework/agents/refactor-advisor.md
@@ -34,7 +34,7 @@ description: |
 
 color: yellow
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 You are the Refactor Advisor, responsible for analyzing a planned change and the existing codebase to identify **preparatory refactoring** — structural improvements to existing code that should be done *before* the main change to make it easier, simpler, and less risky.

--- a/plugins/requirements-framework/agents/refactor-advisor.md
+++ b/plugins/requirements-framework/agents/refactor-advisor.md
@@ -34,7 +34,7 @@ description: |
 
 color: yellow
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 You are the Refactor Advisor, responsible for analyzing a planned change and the existing codebase to identify **preparatory refactoring** — structural improvements to existing code that should be done *before* the main change to make it easier, simpler, and less risky.

--- a/plugins/requirements-framework/agents/session-analyzer.md
+++ b/plugins/requirements-framework/agents/session-analyzer.md
@@ -21,7 +21,7 @@ The session-reflect command automatically invokes this agent.
 </example>
 color: magenta
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 77fcc1e*
+git_hash: 0e41eb9
 ---
 
 You are a session learning analyst. Your role is to analyze session metrics and identify patterns that can improve future Claude Code sessions.

--- a/plugins/requirements-framework/agents/session-analyzer.md
+++ b/plugins/requirements-framework/agents/session-analyzer.md
@@ -20,7 +20,8 @@ The session-reflect command automatically invokes this agent.
 </commentary>
 </example>
 color: magenta
-git_hash: 33b3f9b
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
+git_hash: 77fcc1e*
 ---
 
 You are a session learning analyst. Your role is to analyze session metrics and identify patterns that can improve future Claude Code sessions.

--- a/plugins/requirements-framework/agents/silent-failure-hunter.md
+++ b/plugins/requirements-framework/agents/silent-failure-hunter.md
@@ -20,7 +20,8 @@ user: "I've updated the error handling in the auth module"
 assistant: "Let me use the silent-failure-hunter agent to ensure no silent failures were introduced."
 </example>
 color: blue
-git_hash: 33b3f9b
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
+git_hash: 77fcc1e*
 ---
 
 You are an elite error handling auditor with zero tolerance for silent failures and inadequate error handling. Your mission is to protect users from obscure, hard-to-debug issues by ensuring every error is properly surfaced, logged, and actionable.

--- a/plugins/requirements-framework/agents/silent-failure-hunter.md
+++ b/plugins/requirements-framework/agents/silent-failure-hunter.md
@@ -21,7 +21,7 @@ assistant: "Let me use the silent-failure-hunter agent to ensure no silent failu
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 77fcc1e*
+git_hash: 0e41eb9
 ---
 
 You are an elite error handling auditor with zero tolerance for silent failures and inadequate error handling. Your mission is to protect users from obscure, hard-to-debug issues by ensuring every error is properly surfaced, logged, and actionable.

--- a/plugins/requirements-framework/agents/solid-reviewer.md
+++ b/plugins/requirements-framework/agents/solid-reviewer.md
@@ -24,7 +24,7 @@ SOLID validation is a blocking gate in the plan-review workflow.
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 You are the SOLID Principles Reviewer, responsible for ensuring implementation plans adhere to SOLID design principles before coding begins. You have BLOCKING authority — plans with egregious SOLID violations should not proceed to implementation.

--- a/plugins/requirements-framework/agents/solid-reviewer.md
+++ b/plugins/requirements-framework/agents/solid-reviewer.md
@@ -24,7 +24,7 @@ SOLID validation is a blocking gate in the plan-review workflow.
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 You are the SOLID Principles Reviewer, responsible for ensuring implementation plans adhere to SOLID design principles before coding begins. You have BLOCKING authority — plans with egregious SOLID violations should not proceed to implementation.

--- a/plugins/requirements-framework/agents/tdd-validator.md
+++ b/plugins/requirements-framework/agents/tdd-validator.md
@@ -24,7 +24,7 @@ TDD validation is a blocking gate in the plan-review workflow.
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 You are the TDD Validator, responsible for ensuring all implementation plans include proper Test-Driven Development elements before coding begins. You have BLOCKING authority - plans should not proceed to implementation without TDD readiness.

--- a/plugins/requirements-framework/agents/tdd-validator.md
+++ b/plugins/requirements-framework/agents/tdd-validator.md
@@ -24,7 +24,7 @@ TDD validation is a blocking gate in the plan-review workflow.
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 You are the TDD Validator, responsible for ensuring all implementation plans include proper Test-Driven Development elements before coding begins. You have BLOCKING authority - plans should not proceed to implementation without TDD readiness.

--- a/plugins/requirements-framework/agents/test-analyzer.md
+++ b/plugins/requirements-framework/agents/test-analyzer.md
@@ -20,7 +20,8 @@ user: "check test coverage"
 assistant: "I'll use the test-analyzer agent to review test coverage quality."
 </example>
 color: blue
-git_hash: 33b3f9b
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
+git_hash: 77fcc1e*
 ---
 
 You are an expert test coverage analyst specializing in code review. Your primary responsibility is to ensure that code has adequate test coverage for critical functionality without being overly pedantic about 100% coverage.

--- a/plugins/requirements-framework/agents/test-analyzer.md
+++ b/plugins/requirements-framework/agents/test-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the test-analyzer agent to review test coverage quality."
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 77fcc1e*
+git_hash: 0e41eb9
 ---
 
 You are an expert test coverage analyst specializing in code review. Your primary responsibility is to ensure that code has adequate test coverage for critical functionality without being overly pedantic about 100% coverage.

--- a/plugins/requirements-framework/agents/tool-validator.md
+++ b/plugins/requirements-framework/agents/tool-validator.md
@@ -20,7 +20,7 @@ Tool-validator provides deterministic results matching CI tools.
 </commentary>
 </example>
 color: blue
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 # Tool Validator Agent

--- a/plugins/requirements-framework/agents/tool-validator.md
+++ b/plugins/requirements-framework/agents/tool-validator.md
@@ -20,7 +20,7 @@ Tool-validator provides deterministic results matching CI tools.
 </commentary>
 </example>
 color: blue
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 # Tool Validator Agent

--- a/plugins/requirements-framework/agents/type-design-analyzer.md
+++ b/plugins/requirements-framework/agents/type-design-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the type-design-analyzer agent to evaluate the type invaria
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 77fcc1e*
+git_hash: 0e41eb9
 ---
 
 You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.

--- a/plugins/requirements-framework/agents/type-design-analyzer.md
+++ b/plugins/requirements-framework/agents/type-design-analyzer.md
@@ -20,7 +20,8 @@ user: "check type invariants"
 assistant: "I'll use the type-design-analyzer agent to evaluate the type invariants."
 </example>
 color: blue
-git_hash: 33b3f9b
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
+git_hash: 77fcc1e*
 ---
 
 You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.

--- a/plugins/requirements-framework/commands/arch-review.md
+++ b/plugins/requirements-framework/commands/arch-review.md
@@ -3,7 +3,7 @@ name: arch-review
 description: "Multi-perspective team-based architecture review with agent debate and commit planning"
 argument-hint: "[plan-file-path]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 # Architecture Review — Team-Based Multi-Perspective Assessment

--- a/plugins/requirements-framework/commands/arch-review.md
+++ b/plugins/requirements-framework/commands/arch-review.md
@@ -3,7 +3,7 @@ name: arch-review
 description: "Multi-perspective team-based architecture review with agent debate and commit planning"
 argument-hint: "[plan-file-path]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 # Architecture Review — Team-Based Multi-Perspective Assessment

--- a/plugins/requirements-framework/commands/brainstorm.md
+++ b/plugins/requirements-framework/commands/brainstorm.md
@@ -3,7 +3,7 @@ name: brainstorm
 description: "Design-first development: explore requirements before implementation"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 Invoke the `requirements-framework:brainstorming` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/brainstorm.md
+++ b/plugins/requirements-framework/commands/brainstorm.md
@@ -3,7 +3,7 @@ name: brainstorm
 description: "Design-first development: explore requirements before implementation"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 Invoke the `requirements-framework:brainstorming` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/codex-review.md
+++ b/plugins/requirements-framework/commands/codex-review.md
@@ -3,7 +3,7 @@ name: codex-review
 description: "AI-powered code review using OpenAI Codex"
 argument-hint: "[focus]"
 allowed-tools: ["Bash", "Task"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 # Codex AI Code Review

--- a/plugins/requirements-framework/commands/codex-review.md
+++ b/plugins/requirements-framework/commands/codex-review.md
@@ -3,7 +3,7 @@ name: codex-review
 description: "AI-powered code review using OpenAI Codex"
 argument-hint: "[focus]"
 allowed-tools: ["Bash", "Task"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 # Codex AI Code Review

--- a/plugins/requirements-framework/commands/commit-checks.md
+++ b/plugins/requirements-framework/commands/commit-checks.md
@@ -3,7 +3,7 @@ name: commit-checks
 description: "Auto-fix code quality issues - comment cleanup and import organization"
 argument-hint: "[--skip-autofix]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 # Pre-Commit Auto-Fix

--- a/plugins/requirements-framework/commands/commit-checks.md
+++ b/plugins/requirements-framework/commands/commit-checks.md
@@ -3,7 +3,7 @@ name: commit-checks
 description: "Auto-fix code quality issues - comment cleanup and import organization"
 argument-hint: "[--skip-autofix]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 # Pre-Commit Auto-Fix

--- a/plugins/requirements-framework/commands/deep-review.md
+++ b/plugins/requirements-framework/commands/deep-review.md
@@ -3,7 +3,7 @@ name: deep-review
 description: "Cross-validated team-based code review with agent debate"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 # Deep Review — Cross-Validated Team-Based Code Review

--- a/plugins/requirements-framework/commands/deep-review.md
+++ b/plugins/requirements-framework/commands/deep-review.md
@@ -3,7 +3,7 @@ name: deep-review
 description: "Cross-validated team-based code review with agent debate"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 # Deep Review — Cross-Validated Team-Based Code Review

--- a/plugins/requirements-framework/commands/execute-plan.md
+++ b/plugins/requirements-framework/commands/execute-plan.md
@@ -3,7 +3,7 @@ name: execute-plan
 description: "Execute implementation plan with batch checkpoints and review"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 Invoke the `requirements-framework:executing-plans` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/execute-plan.md
+++ b/plugins/requirements-framework/commands/execute-plan.md
@@ -3,7 +3,7 @@ name: execute-plan
 description: "Execute implementation plan with batch checkpoints and review"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 Invoke the `requirements-framework:executing-plans` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/plan-review.md
+++ b/plugins/requirements-framework/commands/plan-review.md
@@ -3,7 +3,7 @@ name: plan-review
 description: "Validate plan against ADRs, TDD, and SOLID principles, identify preparatory refactoring, then generate atomic commit strategy"
 argument-hint: "[plan-file]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 # Plan Review Command

--- a/plugins/requirements-framework/commands/plan-review.md
+++ b/plugins/requirements-framework/commands/plan-review.md
@@ -3,7 +3,7 @@ name: plan-review
 description: "Validate plan against ADRs, TDD, and SOLID principles, identify preparatory refactoring, then generate atomic commit strategy"
 argument-hint: "[plan-file]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 # Plan Review Command

--- a/plugins/requirements-framework/commands/pre-commit.md
+++ b/plugins/requirements-framework/commands/pre-commit.md
@@ -3,7 +3,7 @@ name: pre-commit
 description: "Quick code review before committing (code + error handling)"
 argument-hint: "[aspects]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 # Pre-Commit Review

--- a/plugins/requirements-framework/commands/pre-commit.md
+++ b/plugins/requirements-framework/commands/pre-commit.md
@@ -3,7 +3,7 @@ name: pre-commit
 description: "Quick code review before committing (code + error handling)"
 argument-hint: "[aspects]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 # Pre-Commit Review

--- a/plugins/requirements-framework/commands/quality-check.md
+++ b/plugins/requirements-framework/commands/quality-check.md
@@ -3,7 +3,7 @@ name: quality-check
 description: "Comprehensive quality review before creating PR"
 argument-hint: "[parallel]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 # Pre-PR Quality Check

--- a/plugins/requirements-framework/commands/quality-check.md
+++ b/plugins/requirements-framework/commands/quality-check.md
@@ -3,7 +3,7 @@ name: quality-check
 description: "Comprehensive quality review before creating PR"
 argument-hint: "[parallel]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 # Pre-PR Quality Check

--- a/plugins/requirements-framework/commands/session-reflect.md
+++ b/plugins/requirements-framework/commands/session-reflect.md
@@ -3,7 +3,7 @@ name: session-reflect
 description: "Review current session and suggest improvements for future sessions"
 argument-hint: "[scope]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 # Session Learning Reflection

--- a/plugins/requirements-framework/commands/session-reflect.md
+++ b/plugins/requirements-framework/commands/session-reflect.md
@@ -3,7 +3,7 @@ name: session-reflect
 description: "Review current session and suggest improvements for future sessions"
 argument-hint: "[scope]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 # Session Learning Reflection

--- a/plugins/requirements-framework/commands/write-plan.md
+++ b/plugins/requirements-framework/commands/write-plan.md
@@ -3,7 +3,7 @@ name: write-plan
 description: "Create detailed implementation plan from requirements or spec"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 33b3f9b
+git_hash: 77fcc1e
 ---
 
 Invoke the `requirements-framework:writing-plans` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/write-plan.md
+++ b/plugins/requirements-framework/commands/write-plan.md
@@ -3,7 +3,7 @@ name: write-plan
 description: "Create detailed implementation plan from requirements or spec"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 77fcc1e
+git_hash: 8398198
 ---
 
 Invoke the `requirements-framework:writing-plans` skill and follow it exactly as presented to you.


### PR DESCRIPTION
## Summary

- Added `allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]` to 11 deep review pool agents that were missing the field, preventing them from using any tools when spawned as teammates during `/deep-review` or `/arch-review`
- Bumped plugin version 2.7.0 → 2.7.1
- Updated git_hash values across all plugin components

## Affected Agents

code-reviewer, silent-failure-hunter, test-analyzer, backward-compatibility-checker, type-design-analyzer, comment-analyzer, code-simplifier, codex-review-agent, codex-arch-reviewer, frontend-reviewer, session-analyzer

## Deep Review Summary

8-agent cross-validated team review completed:
- **CRITICAL**: 0
- **IMPORTANT**: 3 (all follow-up items, not blocking)
  - Arch-review pool agents also missing `SendMessage`/`TaskUpdate` (separate scope)
  - Stale git_hash values (fixed in this PR, CI also handles)
  - No automated frontmatter validation tests (enhancement)
- **SUGGESTION**: 4
- **Verdict**: READY

## Follow-up Items

- [ ] Add `Bash`, `SendMessage`, `TaskUpdate` to arch-review pool agents (adr-guardian, commit-planner, solid-reviewer, tdd-validator, refactor-advisor)
- [ ] Add `allowed-tools` to tool-validator agent
- [ ] Add frontmatter validation tests to prevent regression

## Test plan

- [x] Verified all 19 agents have `allowed-tools` defined (except tool-validator, out of scope)
- [x] Ran `./update-plugin-versions.sh` to update git hashes
- [ ] Test with `claude --plugin-dir ~/Tools/claude-requirements-framework/plugin` and run `/deep-review`