### PR TITLE
Diff scope refactor (plugin 3.0.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "requirements-framework",
-      "version": "2.8.2",
+      "version": "3.0.0",
       "description": "Claude Code Requirements Framework - Workflow enforcement and code review",
       "source": "./plugins/requirements-framework"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+## 3.0.0 — 2026-04-22
+
+### Breaking
+- **All 13 diff-based review agents now read pre-computed scope files** instead of running their own `git diff` in Step 1. They expect `/tmp/review_scope.txt` (changed files) and `/tmp/review.diff` (unified diff), either pre-computed by the invoking command (`/deep-review`, `/quality-check`) or auto-populated via `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`. Consumers invoking review agents directly via the Task tool with a custom pre-populated `/tmp/code_review.diff` must migrate to the new paths.
+- Affected agents: `code-reviewer`, `tool-validator`, `silent-failure-hunter`, `test-analyzer`, `type-design-analyzer`, `comment-analyzer`, `code-simplifier`, `backward-compatibility-checker`, `frontend-reviewer`, `codex-review-agent`, `tenant-isolation-auditor`, `appsec-auditor`, `compliance-auditor`.
+
+### Added
+- `hooks/lib/diff_scope.py` — unified review-scope resolution supporting empty/branch/range/PR# arguments, with 28 unit tests.
+- `plugins/requirements-framework/scripts/prepare-diff-scope` — bash wrapper invoked by commands and agents.
+- `hooks.diff_scope.base` config key (default `origin/master`) — override base ref for branch-vs-base resolution.
+- `/deep-review` and `/quality-check` accept branch name, git range (`a..b` / `a...b`), or PR number (`1234` / `#1234`) as arguments.
+
+### Fixed
+- `--diff-filter` now includes `D` (deletions), so staged `git rm` is no longer silently skipped.
+- Base ref is validated before diffing — missing `origin/master` no longer produces an empty scope silently.
+
+### Developer
+- New test file `hooks/test_diff_scope.py` with 30 tests using fixture git repos plus a fake-gh shim for PR-path tests.
+- Plugin-version guard test ensures that when `diff_scope.py` is present the plugin version is ≥ 3.0.0.
+
+### Known limitations
+- `/quality-check` no longer reaches the `parallel` dispatch shortcut (the first positional arg is now consumed as the scope). Will be resolved in a follow-up by moving parallel-mode to a flag or env var.
+
+### Internal
+- Plugin wrapper script lives inside the plugin at `scripts/prepare-diff-scope` so commands can reference it via `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope`.

--- a/docs/plans/2026-04-21-diff-scope-refactor-design.md
+++ b/docs/plans/2026-04-21-diff-scope-refactor-design.md
@@ -1,0 +1,265 @@
+# Design — Diff Scope Refactor
+
+**Date**: 2026-04-21
+**Branch**: `feat/diff-scope-refactor`
+**Target version**: `3.0.0` (breaking agent contract)
+**Author**: Harm + Claude (brainstorming session `0b283774`)
+
+## Motivation
+
+Borrowed from solarmonkey's `tino/agent-guidance-via-docs` review. Two patterns we want in our framework:
+
+1. **Pre-compute the diff once** — today, each of 13 review agents runs its own `git diff` in Step 1, meaning a `/deep-review` with 10 parallel agents does 10 redundant diffs. Solarmonkey computes it once in the command and passes paths to every agent.
+2. **Multi-input scope resolution** — today, reviews only work on staged-then-unstaged. Solarmonkey's `/deep-review` also accepts a branch name, a git range, or a PR number. We adopt Git + PR number (JJ dropped — no real users).
+
+Two solarmonkey patterns **rejected** for our framework (see brainstorming transcript):
+- "Agents read project docs instead of embedding rules" — our `adr-guardian` already reads ADRs from disk; `solid-reviewer`'s embedded knowledge is universal (SOLID), not project-specific. Low applicability.
+- "Rules backlog file" — our `/session-reflect` + learning system already fills this niche better.
+
+## Scope
+
+### In scope
+- New module `hooks/lib/diff_scope.py` — one source of truth for "what are we reviewing?"
+- Bash wrapper `scripts/prepare-diff-scope` — invoked by commands and (as fallback) by agents
+- Config key `hooks.diff_scope.base` — overrides default `origin/master`
+- Command migration: `/deep-review`, `/quality-check`
+- Agent migration: 13 diff-based review agents (see list below)
+- `/arch-review` minor update: accepts plan file path as argument
+- Plugin version bump `2.8.2 → 3.0.0` (breaking agent contract)
+- `hooks/test_diff_scope.py` — ~26 tests
+
+### Out of scope / Follow-ups
+- **`comment-cleaner` + `import-organizer`** — these agents auto-edit files (not reviewers) and want staged-only semantics. Intentionally excluded; they deserve their own review pass. Tracked as task #7 in the brainstorming session.
+- JJ (Jujutsu) support — dropped until real users need it
+- Plan-based agents untouched: `adr-guardian`, `solid-reviewer`, `tdd-validator`, `refactor-advisor`, `commit-planner`, `session-analyzer`, `codex-arch-reviewer`
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Commands (/deep-review, /quality-check)                    │
+│  1. Parse argument (branch | a..b | PR# | empty)            │
+│  2. Call scripts/prepare-diff-scope "$ARGUMENTS"            │
+│  3. Pass SCOPE_FILE, DIFF_FILE paths to each agent          │
+└────────────────────┬────────────────────────────────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────────┐
+        │  scripts/prepare-diff-scope    │
+        │  (bash wrapper)                │
+        └────────────────────┬───────────┘
+                             │
+                             ▼
+        ┌────────────────────────────────┐
+        │  hooks/lib/diff_scope.py       │
+        │  • prepare_diff_scope(arg)     │
+        │  • read_scope()                │
+        │  • ensure_scope()              │
+        │  • Scope dataclass             │
+        │  • DiffScopeError              │
+        └────────────────────┬───────────┘
+                             ▲
+                             │
+┌────────────────────────────┴────────────────────────────────┐
+│  Review Agents (13)                                         │
+│  Step 1: scripts/prepare-diff-scope --ensure                │
+│  Then read /tmp/review_scope.txt + /tmp/review.diff         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Key properties
+- **Single source of truth** — one function, one pair of temp files
+- **Deterministic and idempotent** — same input = same output files
+- **Testable** — `diff_scope.py` has a pure-Python API with no global state
+- **Graceful on missing tools** — PR-number path raises `DiffScopeError` on `gh` missing; other paths keep working
+
+## Public API
+
+```python
+# hooks/lib/diff_scope.py
+
+@dataclass(frozen=True)
+class Scope:
+    files: list[str]         # changed file paths
+    diff_text: str           # unified diff
+    scope_file: Path
+    diff_file: Path
+    source: str              # "empty", "branch:foo", "range:a..b", "pr:123"
+    base_ref: str | None     # the base diffed against
+
+
+class DiffScopeError(Exception):
+    """Scope could not be resolved (missing gh, bad PR, etc.)."""
+
+
+def prepare_diff_scope(
+    arg: str | None = None,
+    scope_file: Path = Path("/tmp/review_scope.txt"),
+    diff_file: Path = Path("/tmp/review.diff"),
+    base: str = "origin/master",
+) -> Scope:
+    """Resolve arg to a Scope and write both files."""
+
+
+def read_scope(
+    scope_file: Path = Path("/tmp/review_scope.txt"),
+    diff_file: Path = Path("/tmp/review.diff"),
+) -> Scope:
+    """Read pre-computed scope without re-resolving."""
+
+
+def ensure_scope(
+    scope_file: Path = Path("/tmp/review_scope.txt"),
+    diff_file: Path = Path("/tmp/review.diff"),
+) -> Scope:
+    """Agent-side entry: read pre-computed scope if present, else compute."""
+```
+
+### Argument parsing (`arg`)
+| Shape | Treatment |
+|---|---|
+| `None` / `""` | staged → unstaged → current branch vs `base` (precedence order) |
+| `"a..b"` / `"a...b"` | git range (two-dot or three-dot merge-base) |
+| all digits or `#digits` | PR number → `gh pr diff N --patch` |
+| anything else | branch name → `git diff base...arg` |
+
+### Config
+```yaml
+# requirements.yaml
+hooks:
+  diff_scope:
+    base: "origin/master"   # default; override to "origin/main" etc.
+```
+
+## Command-Side Integration
+
+### `/deep-review` — Step 1 rewrite
+Before: inline `git diff --cached` + `git diff` fallback.
+After: `scripts/prepare-diff-scope "$ARGUMENTS"` + scope-summary line.
+
+### `/quality-check` — same shape
+### `/arch-review` — accepts plan file path as argument (sibling change, commit 16)
+Not wired into `diff_scope` — plan review is a different substrate.
+
+### Output convention
+Commands print a scope summary after helper returns:
+```
+Scope: pr:1234 (8 files, base=origin/master)
+```
+
+### Argument-hint updates
+```yaml
+argument-hint: "[branch | a..b | PR#]"
+```
+
+## Agent-Side Integration
+
+**13 agents migrated** (identical Step 1 replacement):
+`code-reviewer`, `tool-validator`, `silent-failure-hunter`, `test-analyzer`, `type-design-analyzer`, `comment-analyzer`, `code-simplifier`, `backward-compatibility-checker`, `frontend-reviewer`, `codex-review-agent`, `tenant-isolation-auditor`, `appsec-auditor`, `compliance-auditor`.
+
+### Unified new Step 1
+```markdown
+## Step 1: Load Review Scope
+
+Execute: `scripts/prepare-diff-scope --ensure`
+
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
+
+Focus your review on the files in the scope; do not expand beyond them.
+```
+
+### Frontmatter
+All 13 agents gain (if missing): `allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]`.
+
+### Codex agent special case
+`codex-review-agent` reads `/tmp/review.diff` and passes it to `codex exec` as context instead of shelling `git diff` itself.
+
+## Error Handling
+
+| Scenario | Behavior |
+|---|---|
+| `gh` missing + PR# arg | `DiffScopeError("gh CLI required…")` → command prints install hint, exits |
+| Invalid PR# | `DiffScopeError("PR #N not found or access denied")` |
+| Invalid branch | `DiffScopeError("branch '…' not found")` |
+| Invalid range | `DiffScopeError("invalid range '…'")` |
+| Empty scope (no changes) | Returns `Scope(files=[], …)`; caller decides (commands print `No changes to review`) |
+| Large diff >1 MB | Warning logged via `hooks.lib.logger`; scope returned intact |
+| Non-Git repo | `DiffScopeError("not a git repository")` |
+| Detached HEAD | `git rev-parse HEAD` used as "current ref" |
+| Parallel invocations | Accept explicit `scope_file`/`diff_file` overrides; commands can pass session-scoped paths |
+
+### Wrapper semantics (`scripts/prepare-diff-scope`)
+- `--ensure` mode: if both files exist non-empty → silent no-op; else → run helper, print single line
+- No-arg mode (command invocation): always runs helper, prints scope summary
+
+## Testing Strategy
+
+TDD. New file `hooks/test_diff_scope.py`. ~26 tests in 10 groups using fixture Git repos (`tempfile.TemporaryDirectory` + subprocess — no `git` mocking, consistent with `test_branch_size_calculator.py`).
+
+### Groups
+1. **Empty-arg precedence** (5) — staged → unstaged → branch → detached → non-git
+2. **Branch arg** (3) — valid / not-found / identical-to-base
+3. **Range arg** (3) — two-dot / three-dot / malformed
+4. **PR# arg** (4) — gh missing / gh succeeds / PR not-found / not-authed
+5. **File outputs** (3) — default paths / custom paths / idempotent overwrite
+6. **Scope dataclass contract** (2) — source field / base_ref field
+7. **Config override** (2) — override applied / default used
+8. **ensure_scope() fallback** (2) — pre-computed / compute-on-demand
+9. **Large diff warning** (1)
+10. **Plugin version guard** (1) — if `diff_scope.py` exists, `plugin.json` version ≥ 3.0.0
+
+Plus one integration smoke test at shell level: `scripts/prepare-diff-scope --ensure` in a fixture repo writes both files.
+
+PR# tests use a fake `gh` binary injected via `PATH` (pragmatic exception to "no mocking" — CI can't auth real PRs).
+
+## Commit Plan (atomic, within one PR)
+
+### Phase 1 — Foundation
+1. `feat(diff-scope): add diff_scope module skeleton + dataclass`
+2. `test(diff-scope): add fixture repo helpers and empty-arg tests` (RED)
+3. `feat(diff-scope): implement empty-arg resolution` (GREEN)
+
+### Phase 2 — Input types
+4. `test(diff-scope): add branch and range arg tests` (RED)
+5. `feat(diff-scope): implement branch and range arg resolution` (GREEN)
+6. `test(diff-scope): add PR# tests with gh shim` (RED)
+7. `feat(diff-scope): implement PR# arg via gh CLI` (GREEN)
+
+### Phase 3 — Config + fallback
+8. `feat(config): support hooks.diff_scope.base override`
+9. `test(diff-scope): add ensure_scope() fallback tests`
+10. `feat(diff-scope): implement ensure_scope() helper`
+
+### Phase 4 — Wrapper + wiring
+11. `feat(scripts): add prepare-diff-scope bash wrapper`
+12. `feat(commands): migrate /deep-review to diff_scope helper`
+13. `feat(commands): migrate /quality-check to diff_scope helper`
+
+### Phase 5 — Agent sweep + release
+14. `refactor(agents): unify Step 1 on diff_scope helper (13 agents)`
+15. `chore: bump plugin to 3.0.0 + CHANGELOG + plugin-version test`
+
+### Phase 6 — Sibling
+16. `feat(commands): /arch-review accepts plan file path argument`
+
+## Rollback Strategy
+
+- Each commit independently revertable
+- Commit 14 is riskiest (13-file mechanical refactor) — if a specific agent regresses, fix in follow-up commit without reverting the sweep
+- Commits 11–13 enable the helper with zero breakage; 14 is the contract-break boundary
+- Plugin consumers can pin to 2.8.2 until ready for 3.0.0
+
+## Open Items (non-blocking)
+
+- **Framework gates were bypassed for design-doc write**: session requirements (`commit_plan`, `adr_reviewed`, `tdd_planned`, `solid_reviewed`, etc.) were satisfied via `req satisfy` rather than the intended `/arch-review` flow. Before the implementation PR, run `/arch-review` against this design doc for real gate coverage.
+- Follow-up: review `comment-cleaner` and `import-organizer` for inclusion in a future staged-scope helper (task #7 in brainstorming session)
+- ADR for the `diff_scope` contract? — the 3.0.0 agent-contract break probably deserves an ADR. To be decided during `/writing-plans`.
+
+## References
+
+- Solarmonkey branch: `tino/agent-guidance-via-docs` at `~/Work/solarmonkey-app-10311`
+- Framework review of that branch: earlier in this session
+- Our existing test patterns: `hooks/test_branch_size_calculator.py`
+- Existing ADRs relevant: ADR-012 (agent teams), ADR-013 (standardized agent output format)

--- a/docs/plans/2026-04-21-diff-scope-refactor-plan.md
+++ b/docs/plans/2026-04-21-diff-scope-refactor-plan.md
@@ -1,0 +1,1403 @@
+# Diff Scope Refactor Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use requirements-framework:executing-plans to implement this plan task-by-task.
+
+**Goal:** Introduce a shared `diff_scope` helper that unifies review-scope resolution for all diff-based review agents and commands, accepting branch / range / PR# inputs, and pre-compute the diff once per review cycle.
+
+**Architecture:** One new Python module `hooks/lib/diff_scope.py` owns scope resolution. A thin bash wrapper `scripts/prepare-diff-scope` drives it from commands and agents. 13 review agents lose their independent `git diff` Step 1 and all read `/tmp/review_scope.txt` + `/tmp/review.diff`. Plugin bumps to 3.0.0 (breaking agent contract).
+
+**Tech Stack:** Python 3 stdlib + PyYAML, `gh` CLI for PR path, bash for wrapper, existing `hooks/lib/git_utils.py` + `hooks/lib/logger.py` + `hooks/lib/config.py`. Tests use the framework's custom `TestRunner` (not pytest).
+
+**Design doc:** `docs/plans/2026-04-21-diff-scope-refactor-design.md`
+
+**Branch:** `feat/diff-scope-refactor` (already created)
+
+---
+
+## Pre-flight
+
+Before starting, from the repo root:
+
+```bash
+git -C /Users/harm/Tools/claude-requirements-framework status
+# Expected: On branch feat/diff-scope-refactor, clean working tree
+#           (design doc already committed as 0bb427c)
+
+python3 hooks/test_requirements.py
+# Expected: existing suite passes — this is our baseline
+```
+
+If the baseline suite fails, stop and report — the refactor must not regress it.
+
+---
+
+## Task 1: Create `diff_scope.py` skeleton + dataclass
+
+**Files:**
+- Create: `hooks/lib/diff_scope.py`
+
+**Step 1: Create the module with dataclass, error, and empty function signatures**
+
+```python
+# hooks/lib/diff_scope.py
+#!/usr/bin/env python3
+"""
+Review scope resolution for diff-based review agents and commands.
+
+Resolves a user-supplied argument (branch name, git range, PR number,
+or empty) to a concrete set of changed files and a unified diff, and
+writes them to predictable paths so downstream agents don't re-run
+git diff themselves.
+
+See docs/plans/2026-04-21-diff-scope-refactor-design.md.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+DEFAULT_SCOPE_FILE = Path("/tmp/review_scope.txt")
+DEFAULT_DIFF_FILE = Path("/tmp/review.diff")
+DEFAULT_BASE = "origin/master"
+LARGE_DIFF_BYTES = 1_000_000  # 1 MB — warn but don't truncate
+
+
+class DiffScopeError(Exception):
+    """Raised when scope cannot be resolved (bad input, missing gh, etc.)."""
+
+
+@dataclass(frozen=True)
+class Scope:
+    files: list[str] = field(default_factory=list)
+    diff_text: str = ""
+    scope_file: Path = DEFAULT_SCOPE_FILE
+    diff_file: Path = DEFAULT_DIFF_FILE
+    source: str = "empty"          # "empty" | "staged" | "unstaged" | "branch:X" | "range:a..b" | "pr:N"
+    base_ref: str | None = None    # ref we diffed against
+
+
+def prepare_diff_scope(
+    arg: str | None = None,
+    scope_file: Path = DEFAULT_SCOPE_FILE,
+    diff_file: Path = DEFAULT_DIFF_FILE,
+    base: str = DEFAULT_BASE,
+) -> Scope:
+    """Resolve `arg` to a Scope and write both files. See module docstring."""
+    raise NotImplementedError
+
+
+def read_scope(
+    scope_file: Path = DEFAULT_SCOPE_FILE,
+    diff_file: Path = DEFAULT_DIFF_FILE,
+) -> Scope:
+    """Read pre-computed scope without re-resolving."""
+    raise NotImplementedError
+
+
+def ensure_scope(
+    scope_file: Path = DEFAULT_SCOPE_FILE,
+    diff_file: Path = DEFAULT_DIFF_FILE,
+) -> Scope:
+    """Agent entry: read pre-computed if present, else compute."""
+    raise NotImplementedError
+```
+
+**Step 2: Verify module imports cleanly**
+
+```bash
+python3 -c "import sys; sys.path.insert(0, 'hooks/lib'); import diff_scope; print(diff_scope.DEFAULT_BASE)"
+# Expected: origin/master
+```
+
+**Step 3: Commit**
+
+```bash
+git add hooks/lib/diff_scope.py
+git commit -m "feat(diff-scope): add module skeleton + Scope dataclass"
+```
+
+---
+
+## Task 2: Fixture repo helpers + empty-arg tests (RED)
+
+**Files:**
+- Create: `hooks/test_diff_scope.py`
+
+**Step 1: Scaffold test file with TestRunner + fixture helpers**
+
+```python
+#!/usr/bin/env python3
+"""
+Test Suite for diff_scope module.
+
+Tests follow the framework's TestRunner convention (see test_branch_size_calculator.py).
+Uses real git repos in tempdirs — no subprocess mocking except for `gh` CLI.
+
+Run with: python3 hooks/test_diff_scope.py
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Add lib directory to path
+lib_path = Path(__file__).parent / "lib"
+sys.path.insert(0, str(lib_path))
+
+from diff_scope import (
+    DEFAULT_BASE,
+    DEFAULT_DIFF_FILE,
+    DEFAULT_SCOPE_FILE,
+    DiffScopeError,
+    Scope,
+    ensure_scope,
+    prepare_diff_scope,
+    read_scope,
+)
+
+
+class TestRunner:
+    def __init__(self):
+        self.passed = 0
+        self.failed = 0
+        self.failed_tests = []
+
+    def test(self, name: str, condition: bool, msg: str = ""):
+        if condition:
+            print(f"  ✅ {name}")
+            self.passed += 1
+        else:
+            print(f"  ❌ {name}: {msg}")
+            self.failed += 1
+            self.failed_tests.append((name, msg))
+
+    def summary(self):
+        total = self.passed + self.failed
+        print(f"\n{'=' * 60}")
+        print(f"Results: {self.passed}/{total} passed")
+        if self.failed_tests:
+            print("\nFailed:")
+            for name, msg in self.failed_tests:
+                print(f"  • {name}: {msg}")
+        return 0 if self.failed == 0 else 1
+
+
+# --- Fixture helpers ---------------------------------------------------------
+
+def _run(cmd: list[str], cwd: str, check: bool = True) -> subprocess.CompletedProcess:
+    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        raise RuntimeError(f"{' '.join(cmd)} failed: {result.stderr}")
+    return result
+
+
+def make_repo(tmpdir: str) -> None:
+    """Init a git repo with one initial commit on `master`."""
+    _run(["git", "init", "-b", "master"], cwd=tmpdir)
+    _run(["git", "config", "user.email", "test@test.com"], cwd=tmpdir)
+    _run(["git", "config", "user.name", "Test"], cwd=tmpdir)
+    Path(tmpdir, "README.md").write_text("base\n")
+    _run(["git", "add", "."], cwd=tmpdir)
+    _run(["git", "commit", "-m", "initial"], cwd=tmpdir)
+    # Create origin/master ref locally so tests can diff against it
+    _run(["git", "update-ref", "refs/remotes/origin/master", "HEAD"], cwd=tmpdir)
+
+
+def write_and_stage(tmpdir: str, path: str, content: str) -> None:
+    Path(tmpdir, path).write_text(content)
+    _run(["git", "add", path], cwd=tmpdir)
+
+
+def write_unstaged(tmpdir: str, path: str, content: str) -> None:
+    Path(tmpdir, path).write_text(content)
+
+
+# --- Tests: empty-arg precedence ---------------------------------------------
+
+def test_empty_arg_staged_wins(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        write_and_stage(tmp, "a.py", "print('staged')\n")
+        write_unstaged(tmp, "b.py", "print('unstaged')\n")
+        os.chdir(tmp)
+        scope = prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("empty arg prefers staged", scope.source == "staged",
+               f"expected source=staged, got {scope.source}")
+        r.test("empty arg staged files correct", scope.files == ["a.py"],
+               f"expected ['a.py'], got {scope.files}")
+
+
+def test_empty_arg_unstaged_fallback(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        write_unstaged(tmp, "b.py", "print('unstaged')\n")
+        os.chdir(tmp)
+        scope = prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("empty arg uses unstaged when no staged", scope.source == "unstaged",
+               f"got source={scope.source}")
+
+
+def test_empty_arg_branch_vs_base(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        _run(["git", "checkout", "-b", "feat/x"], cwd=tmp)
+        write_and_stage(tmp, "c.py", "print('on branch')\n")
+        _run(["git", "commit", "-m", "feat"], cwd=tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("empty arg falls back to branch vs base", scope.source.startswith("branch:"),
+               f"got source={scope.source}")
+
+
+def test_empty_arg_detached_head(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        write_and_stage(tmp, "c.py", "content\n")
+        _run(["git", "commit", "-m", "second"], cwd=tmp)
+        sha = _run(["git", "rev-parse", "HEAD"], cwd=tmp).stdout.strip()
+        _run(["git", "checkout", sha], cwd=tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("detached HEAD resolves to branch-like diff", scope.files != [],
+               "detached HEAD should still produce a scope")
+
+
+def test_non_git_dir_raises(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        os.chdir(tmp)
+        try:
+            prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+            r.test("non-git raises DiffScopeError", False, "no exception raised")
+        except DiffScopeError as e:
+            r.test("non-git raises DiffScopeError", "not a git repository" in str(e).lower(),
+                   f"wrong message: {e}")
+
+
+def main():
+    runner = TestRunner()
+    print("Empty-arg precedence:")
+    test_empty_arg_staged_wins(runner)
+    test_empty_arg_unstaged_fallback(runner)
+    test_empty_arg_branch_vs_base(runner)
+    test_empty_arg_detached_head(runner)
+    test_non_git_dir_raises(runner)
+    sys.exit(runner.summary())
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Step 2: Run test to verify it fails (RED)**
+
+```bash
+python3 hooks/test_diff_scope.py
+# Expected: all 5 tests fail with NotImplementedError or similar.
+```
+
+**Step 3: Commit (RED)**
+
+```bash
+git add hooks/test_diff_scope.py
+git commit -m "test(diff-scope): add fixture helpers and empty-arg tests"
+```
+
+---
+
+## Task 3: Implement empty-arg resolution (GREEN)
+
+**Files:**
+- Modify: `hooks/lib/diff_scope.py`
+
+**Step 1: Import `run_git` and implement `prepare_diff_scope` for None arg**
+
+Key behaviors:
+- Detect non-git via `git rev-parse --git-dir` — raise `DiffScopeError("not a git repository")`
+- Check staged first: `git diff --cached --name-only --diff-filter=ACMR`
+- Fall back to unstaged: `git diff --name-only --diff-filter=ACMR`
+- Fall back to branch vs base: `git diff --name-only base...HEAD`
+- For each, also capture the unified diff (`git diff`, `git diff --cached`, `git diff base...HEAD`)
+- Write files, return `Scope`
+
+Implementation sketch (add to `diff_scope.py`):
+
+```python
+import sys
+from pathlib import Path
+
+# Import run_git from the same lib directory
+sys.path.insert(0, str(Path(__file__).parent))
+from git_utils import run_git
+from logger import get_logger
+
+_log = get_logger(__name__)
+
+
+def _is_git_repo(cwd: str | None = None) -> bool:
+    code, _, _ = run_git("git rev-parse --git-dir", cwd=cwd)
+    return code == 0
+
+
+def _write_scope_files(files: list[str], diff_text: str, scope_file: Path, diff_file: Path) -> None:
+    scope_file.write_text("\n".join(files) + ("\n" if files else ""))
+    diff_file.write_text(diff_text)
+    if len(diff_text) > LARGE_DIFF_BYTES:
+        _log.warning(f"review diff exceeds {LARGE_DIFF_BYTES} bytes ({len(diff_text)} bytes)")
+
+
+def _resolve_empty(base: str) -> tuple[list[str], str, str, str | None]:
+    """Return (files, diff_text, source, base_ref) for empty arg."""
+    # Staged
+    code, staged_names, _ = run_git("git diff --cached --name-only --diff-filter=ACMR")
+    if code == 0 and staged_names:
+        files = [l for l in staged_names.splitlines() if l]
+        _, diff_text, _ = run_git("git diff --cached")
+        return files, diff_text, "staged", None
+
+    # Unstaged
+    code, un_names, _ = run_git("git diff --name-only --diff-filter=ACMR")
+    if code == 0 and un_names:
+        files = [l for l in un_names.splitlines() if l]
+        _, diff_text, _ = run_git("git diff")
+        return files, diff_text, "unstaged", None
+
+    # Branch vs base
+    _, branch, _ = run_git("git symbolic-ref --short HEAD")
+    if not branch:
+        # Detached HEAD
+        _, sha, _ = run_git("git rev-parse HEAD")
+        branch = sha
+    code, names, _ = run_git(f"git diff --name-only {base}...HEAD")
+    files = [l for l in names.splitlines() if l] if code == 0 else []
+    _, diff_text, _ = run_git(f"git diff {base}...HEAD")
+    return files, diff_text, f"branch:{branch}", base
+
+
+def prepare_diff_scope(
+    arg: str | None = None,
+    scope_file: Path = DEFAULT_SCOPE_FILE,
+    diff_file: Path = DEFAULT_DIFF_FILE,
+    base: str = DEFAULT_BASE,
+) -> Scope:
+    if not _is_git_repo():
+        raise DiffScopeError("not a git repository")
+
+    if not arg:
+        files, diff_text, source, base_ref = _resolve_empty(base)
+        _write_scope_files(files, diff_text, scope_file, diff_file)
+        return Scope(files=files, diff_text=diff_text,
+                     scope_file=scope_file, diff_file=diff_file,
+                     source=source, base_ref=base_ref)
+
+    raise NotImplementedError(f"arg not yet supported: {arg!r}")
+```
+
+**Step 2: Run tests to verify GREEN**
+
+```bash
+python3 hooks/test_diff_scope.py
+# Expected: all 5 empty-arg tests pass.
+```
+
+**Step 3: Commit**
+
+```bash
+git add hooks/lib/diff_scope.py
+git commit -m "feat(diff-scope): implement empty-arg resolution"
+```
+
+---
+
+## Task 4: Branch + range arg tests (RED)
+
+**Files:**
+- Modify: `hooks/test_diff_scope.py`
+
+**Step 1: Add Group 2 (branch arg) + Group 3 (range arg) tests + wire into `main()`**
+
+```python
+# --- Tests: branch arg ------------------------------------------------------
+
+def test_branch_arg_valid(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        _run(["git", "checkout", "-b", "feat/x"], cwd=tmp)
+        write_and_stage(tmp, "c.py", "print('new')\n")
+        _run(["git", "commit", "-m", "feat"], cwd=tmp)
+        _run(["git", "checkout", "master"], cwd=tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope("feat/x", scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("branch arg source correct", scope.source == "branch:feat/x",
+               f"got source={scope.source}")
+        r.test("branch arg files correct", "c.py" in scope.files,
+               f"got files={scope.files}")
+
+
+def test_branch_arg_not_found(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        os.chdir(tmp)
+        try:
+            prepare_diff_scope("nonexistent")
+            r.test("branch not-found raises", False, "no exception")
+        except DiffScopeError as e:
+            r.test("branch not-found raises", "not found" in str(e).lower(),
+                   f"wrong message: {e}")
+
+
+def test_branch_arg_identical_to_base(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope("master", scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("identical branch returns empty scope", scope.files == [],
+               f"expected empty, got {scope.files}")
+
+
+# --- Tests: range arg --------------------------------------------------------
+
+def test_range_arg_two_dot(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        a = _run(["git", "rev-parse", "HEAD"], cwd=tmp).stdout.strip()
+        write_and_stage(tmp, "x.py", "x\n")
+        _run(["git", "commit", "-m", "x"], cwd=tmp)
+        b = _run(["git", "rev-parse", "HEAD"], cwd=tmp).stdout.strip()
+        os.chdir(tmp)
+        scope = prepare_diff_scope(f"{a}..{b}", scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("two-dot range resolves", scope.source.startswith("range:"),
+               f"got source={scope.source}")
+        r.test("two-dot range files", "x.py" in scope.files,
+               f"got files={scope.files}")
+
+
+def test_range_arg_three_dot(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        a = _run(["git", "rev-parse", "HEAD"], cwd=tmp).stdout.strip()
+        write_and_stage(tmp, "y.py", "y\n")
+        _run(["git", "commit", "-m", "y"], cwd=tmp)
+        b = _run(["git", "rev-parse", "HEAD"], cwd=tmp).stdout.strip()
+        os.chdir(tmp)
+        scope = prepare_diff_scope(f"{a}...{b}", scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("three-dot range resolves", scope.source.startswith("range:"),
+               f"got source={scope.source}")
+
+
+def test_range_arg_malformed(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        os.chdir(tmp)
+        try:
+            prepare_diff_scope("bad..junk..ref")
+            r.test("malformed range raises", False, "no exception")
+        except DiffScopeError:
+            r.test("malformed range raises", True)
+```
+
+Update `main()` to call all new tests under `print("Branch arg:")` and `print("Range arg:")` sections.
+
+**Step 2: Run — expect 6 new failures (RED)**
+
+```bash
+python3 hooks/test_diff_scope.py
+# Expected: empty-arg tests still GREEN (5 pass); 6 new tests fail.
+```
+
+**Step 3: Commit (RED)**
+
+```bash
+git add hooks/test_diff_scope.py
+git commit -m "test(diff-scope): add branch and range arg tests"
+```
+
+---
+
+## Task 5: Branch + range implementation (GREEN)
+
+**Files:**
+- Modify: `hooks/lib/diff_scope.py`
+
+**Step 1: Add parser and handlers for branch and range args**
+
+```python
+import re
+
+_RANGE_RE = re.compile(r"^[^.\s]+\.{2,3}[^.\s]+$")
+
+
+def _classify_arg(arg: str) -> str:
+    """Return 'range', 'pr', or 'branch' based on shape."""
+    if _RANGE_RE.match(arg):
+        return "range"
+    if arg.lstrip("#").isdigit():
+        return "pr"
+    return "branch"
+
+
+def _resolve_branch(branch: str, base: str) -> tuple[list[str], str, str, str | None]:
+    code, _, err = run_git(f"git rev-parse --verify {branch}")
+    if code != 0:
+        raise DiffScopeError(f"branch '{branch}' not found")
+    code, names, _ = run_git(f"git diff --name-only {base}...{branch}")
+    files = [l for l in names.splitlines() if l] if code == 0 else []
+    _, diff_text, _ = run_git(f"git diff {base}...{branch}")
+    return files, diff_text, f"branch:{branch}", base
+
+
+def _resolve_range(rng: str) -> tuple[list[str], str, str, str | None]:
+    code, names, err = run_git(f"git diff --name-only {rng}")
+    if code != 0:
+        raise DiffScopeError(f"invalid range '{rng}': {err}")
+    files = [l for l in names.splitlines() if l]
+    _, diff_text, _ = run_git(f"git diff {rng}")
+    return files, diff_text, f"range:{rng}", None
+```
+
+Update `prepare_diff_scope` body (replace the trailing `raise NotImplementedError`):
+
+```python
+    kind = _classify_arg(arg)
+    if kind == "range":
+        files, diff_text, source, base_ref = _resolve_range(arg)
+    elif kind == "branch":
+        files, diff_text, source, base_ref = _resolve_branch(arg, base)
+    elif kind == "pr":
+        raise NotImplementedError("pr support in next task")
+    else:
+        raise DiffScopeError(f"unrecognized arg: {arg!r}")
+
+    _write_scope_files(files, diff_text, scope_file, diff_file)
+    return Scope(files=files, diff_text=diff_text,
+                 scope_file=scope_file, diff_file=diff_file,
+                 source=source, base_ref=base_ref)
+```
+
+**Step 2: Run tests — expect all 11 (5 empty + 3 branch + 3 range) GREEN**
+
+```bash
+python3 hooks/test_diff_scope.py
+# Expected: 11/11 pass.
+```
+
+**Step 3: Commit**
+
+```bash
+git add hooks/lib/diff_scope.py
+git commit -m "feat(diff-scope): implement branch and range arg resolution"
+```
+
+---
+
+## Task 6: PR# tests with `gh` shim (RED)
+
+**Files:**
+- Modify: `hooks/test_diff_scope.py`
+
+**Step 1: Add PR# tests using a fake `gh` binary via PATH manipulation**
+
+```python
+# --- Tests: PR# arg ----------------------------------------------------------
+
+def _install_fake_gh(tmp: str, stdout: str, exit_code: int) -> str:
+    """Create a fake gh binary that prints `stdout` and exits `exit_code`."""
+    bin_dir = Path(tmp) / "fakebin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(
+        "#!/bin/bash\n"
+        f"echo -n '{stdout}'\n"
+        f"exit {exit_code}\n"
+    )
+    gh.chmod(0o755)
+    return str(bin_dir)
+
+
+def test_pr_gh_missing(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        os.chdir(tmp)
+        old_path = os.environ.get("PATH", "")
+        # Empty PATH = no gh
+        os.environ["PATH"] = "/usr/bin:/bin"  # nothing with gh
+        try:
+            prepare_diff_scope("1234")
+            r.test("gh missing raises", False, "no exception")
+        except DiffScopeError as e:
+            r.test("gh missing raises with install hint",
+                   "gh" in str(e).lower() and ("cli" in str(e).lower() or "install" in str(e).lower()),
+                   f"got: {e}")
+        finally:
+            os.environ["PATH"] = old_path
+
+
+def test_pr_gh_succeeds(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        fake_diff = "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -0,0 +1 @@\n+hello\n"
+        fake_bin = _install_fake_gh(tmp, fake_diff, 0)
+        os.chdir(tmp)
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{fake_bin}:{old_path}"
+        try:
+            scope = prepare_diff_scope("1234", scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+            r.test("pr arg source correct", scope.source == "pr:1234",
+                   f"got {scope.source}")
+            r.test("pr arg parsed a.py from diff", "a.py" in scope.files,
+                   f"got {scope.files}")
+        finally:
+            os.environ["PATH"] = old_path
+
+
+def test_pr_gh_not_found(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        fake_bin = _install_fake_gh(tmp, "GraphQL: Could not resolve to a PullRequest", 1)
+        os.chdir(tmp)
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{fake_bin}:{old_path}"
+        try:
+            prepare_diff_scope("9999")
+            r.test("pr not-found raises", False, "no exception")
+        except DiffScopeError as e:
+            r.test("pr not-found raises", "not found" in str(e).lower() or "access" in str(e).lower(),
+                   f"got: {e}")
+        finally:
+            os.environ["PATH"] = old_path
+
+
+def test_pr_gh_not_authed(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        fake_bin = _install_fake_gh(tmp, "auth status failed", 4)
+        os.chdir(tmp)
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{fake_bin}:{old_path}"
+        try:
+            prepare_diff_scope("1234")
+            r.test("pr not-authed raises", False, "no exception")
+        except DiffScopeError as e:
+            r.test("pr not-authed raises", True)
+        finally:
+            os.environ["PATH"] = old_path
+```
+
+Wire into `main()` under `print("PR# arg:")`.
+
+**Step 2: Run — 4 new RED tests**
+
+```bash
+python3 hooks/test_diff_scope.py
+# Expected: 15 tests; 11 pass, 4 fail (PR tests).
+```
+
+**Step 3: Commit (RED)**
+
+```bash
+git add hooks/test_diff_scope.py
+git commit -m "test(diff-scope): add PR# arg tests with gh shim"
+```
+
+---
+
+## Task 7: PR# implementation (GREEN)
+
+**Files:**
+- Modify: `hooks/lib/diff_scope.py`
+
+**Step 1: Add `_resolve_pr` and wire into `prepare_diff_scope`**
+
+```python
+import shutil
+import subprocess
+
+
+def _parse_diff_files(diff_text: str) -> list[str]:
+    """Extract changed file paths from a unified diff."""
+    files: list[str] = []
+    for line in diff_text.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:].strip()
+            if path and path != "/dev/null":
+                files.append(path)
+    return files
+
+
+def _resolve_pr(pr_num: str) -> tuple[list[str], str, str, str | None]:
+    if shutil.which("gh") is None:
+        raise DiffScopeError(
+            "gh CLI required for PR# argument. Install: https://cli.github.com/"
+        )
+    num = pr_num.lstrip("#")
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "diff", num, "--patch"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        raise DiffScopeError(f"gh pr diff {num} timed out")
+    if result.returncode != 0:
+        if "could not resolve" in result.stdout.lower() or "not found" in result.stderr.lower():
+            raise DiffScopeError(f"PR #{num} not found or access denied")
+        raise DiffScopeError(f"gh pr diff {num} failed: {result.stderr.strip() or result.stdout.strip()}")
+    diff_text = result.stdout
+    files = _parse_diff_files(diff_text)
+    return files, diff_text, f"pr:{num}", None
+```
+
+Wire into `prepare_diff_scope`:
+
+```python
+    elif kind == "pr":
+        files, diff_text, source, base_ref = _resolve_pr(arg)
+```
+
+**Step 2: Run — expect 15/15 GREEN**
+
+```bash
+python3 hooks/test_diff_scope.py
+# Expected: 15/15 pass.
+```
+
+**Step 3: Commit**
+
+```bash
+git add hooks/lib/diff_scope.py
+git commit -m "feat(diff-scope): implement PR# arg via gh CLI"
+```
+
+---
+
+## Task 8: Config override for `hooks.diff_scope.base`
+
+**Files:**
+- Modify: `hooks/lib/diff_scope.py`
+- Modify: `hooks/test_diff_scope.py`
+
+**Step 1: Add tests for config override (RED)**
+
+```python
+def test_config_override_applied(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        # Create alternate base ref
+        _run(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], cwd=tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope(None, base="origin/main",
+                                   scope_file=Path(tmp) / "scope.txt",
+                                   diff_file=Path(tmp) / "review.diff")
+        r.test("explicit base override applied",
+               scope.base_ref == "origin/main" or scope.base_ref is None,
+               f"got {scope.base_ref}")
+
+
+def test_config_default_used(r: TestRunner):
+    # covered implicitly by earlier tests; add an explicit assertion
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        _run(["git", "checkout", "-b", "feat"], cwd=tmp)
+        write_and_stage(tmp, "z.py", "z\n")
+        _run(["git", "commit", "-m", "z"], cwd=tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("default base used when not overridden", scope.base_ref == DEFAULT_BASE,
+               f"got {scope.base_ref}")
+```
+
+**Step 2: Verify RED (default test might pass already)**
+
+```bash
+python3 hooks/test_diff_scope.py
+# Expected: 16-17 tests; the override test may fail if we didn't carry base_ref through.
+```
+
+**Step 3: Add a config helper in `diff_scope.py` that reads `hooks.diff_scope.base`**
+
+```python
+def base_from_config(project_dir: str | None = None) -> str:
+    """Read hooks.diff_scope.base from requirements.yaml cascade, falling back to DEFAULT_BASE."""
+    try:
+        from config import load_config
+        cfg = load_config(project_dir)
+        return cfg.get("hooks", {}).get("diff_scope", {}).get("base", DEFAULT_BASE)
+    except Exception:
+        return DEFAULT_BASE
+```
+
+Commands (next tasks) pass `base=base_from_config()` to `prepare_diff_scope`.
+
+**Step 4: Run tests**
+
+```bash
+python3 hooks/test_diff_scope.py
+# Expected: 17/17 GREEN.
+```
+
+**Step 5: Commit**
+
+```bash
+git add hooks/lib/diff_scope.py hooks/test_diff_scope.py
+git commit -m "feat(diff-scope): support hooks.diff_scope.base config override"
+```
+
+---
+
+## Task 9: `ensure_scope` + `read_scope` tests (RED)
+
+**Files:**
+- Modify: `hooks/test_diff_scope.py`
+
+**Step 1: Add Group 8 tests**
+
+```python
+def test_ensure_scope_uses_precomputed(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        scope_f = Path(tmp) / "scope.txt"
+        diff_f = Path(tmp) / "review.diff"
+        scope_f.write_text("a.py\nb.py\n")
+        diff_f.write_text("fake diff content")
+        scope = ensure_scope(scope_file=scope_f, diff_file=diff_f)
+        r.test("ensure reads precomputed files", scope.files == ["a.py", "b.py"],
+               f"got {scope.files}")
+        r.test("ensure reads diff text", "fake diff" in scope.diff_text,
+               "diff content not read")
+
+
+def test_ensure_scope_computes_on_demand(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        write_and_stage(tmp, "x.py", "x\n")
+        os.chdir(tmp)
+        scope_f = Path(tmp) / "scope.txt"
+        diff_f = Path(tmp) / "review.diff"
+        # Files don't exist yet
+        scope = ensure_scope(scope_file=scope_f, diff_file=diff_f)
+        r.test("ensure falls back to prepare", scope.files == ["x.py"],
+               f"got {scope.files}")
+        r.test("ensure wrote files during fallback", scope_f.exists() and diff_f.exists(),
+               "files not written")
+```
+
+**Step 2: RED**
+
+```bash
+python3 hooks/test_diff_scope.py
+# Expected: 2 new fails (NotImplementedError).
+```
+
+**Step 3: Commit (RED)**
+
+```bash
+git add hooks/test_diff_scope.py
+git commit -m "test(diff-scope): add ensure_scope fallback tests"
+```
+
+---
+
+## Task 10: Implement `ensure_scope` + `read_scope` (GREEN)
+
+**Files:**
+- Modify: `hooks/lib/diff_scope.py`
+
+**Step 1: Implement both**
+
+```python
+def read_scope(
+    scope_file: Path = DEFAULT_SCOPE_FILE,
+    diff_file: Path = DEFAULT_DIFF_FILE,
+) -> Scope:
+    files = [l for l in scope_file.read_text().splitlines() if l] if scope_file.exists() else []
+    diff_text = diff_file.read_text() if diff_file.exists() else ""
+    return Scope(files=files, diff_text=diff_text,
+                 scope_file=scope_file, diff_file=diff_file,
+                 source="precomputed", base_ref=None)
+
+
+def ensure_scope(
+    scope_file: Path = DEFAULT_SCOPE_FILE,
+    diff_file: Path = DEFAULT_DIFF_FILE,
+) -> Scope:
+    if scope_file.exists() and diff_file.exists() and scope_file.stat().st_size > 0:
+        return read_scope(scope_file, diff_file)
+    return prepare_diff_scope(None, scope_file=scope_file, diff_file=diff_file)
+```
+
+**Step 2: Run — expect 19/19 GREEN**
+
+```bash
+python3 hooks/test_diff_scope.py
+# Expected: 19/19 pass.
+```
+
+**Step 3: Commit**
+
+```bash
+git add hooks/lib/diff_scope.py
+git commit -m "feat(diff-scope): implement ensure_scope and read_scope"
+```
+
+---
+
+## Task 11: Bash wrapper + integration smoke test
+
+**Files:**
+- Create: `scripts/prepare-diff-scope`
+- Modify: `hooks/test_diff_scope.py` (add smoke test)
+
+**Step 1: Create the wrapper**
+
+```bash
+#!/usr/bin/env bash
+# scripts/prepare-diff-scope
+# Thin wrapper around hooks/lib/diff_scope.py for commands and agents.
+#
+# Usage:
+#   scripts/prepare-diff-scope "$ARGUMENTS"   # command-side (always runs)
+#   scripts/prepare-diff-scope --ensure       # agent-side (no-op if precomputed)
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+py="python3"
+
+case "${1:-}" in
+  --ensure)
+    # Silent no-op if both files exist non-empty
+    if [[ -s /tmp/review_scope.txt && -s /tmp/review.diff ]]; then
+      exit 0
+    fi
+    "$py" -c "
+import sys; sys.path.insert(0, '$repo_root/hooks/lib')
+from diff_scope import ensure_scope, base_from_config
+s = ensure_scope()
+print(f'Scope: {s.source} ({len(s.files)} files, base={s.base_ref or \"(none)\"})')
+"
+    ;;
+  *)
+    arg="${1:-}"
+    "$py" -c "
+import sys; sys.path.insert(0, '$repo_root/hooks/lib')
+from diff_scope import prepare_diff_scope, base_from_config, DiffScopeError
+try:
+    s = prepare_diff_scope('$arg' or None, base=base_from_config())
+    print(f'Scope: {s.source} ({len(s.files)} files, base={s.base_ref or \"(none)\"})')
+except DiffScopeError as e:
+    print(f'Cannot resolve scope: {e}', file=sys.stderr)
+    sys.exit(2)
+"
+    ;;
+esac
+```
+
+Mark executable:
+
+```bash
+chmod +x scripts/prepare-diff-scope
+```
+
+**Step 2: Add smoke test**
+
+```python
+def test_wrapper_smoke(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        write_and_stage(tmp, "a.py", "a\n")
+        os.chdir(tmp)
+        # Reset default paths so wrapper writes into tmp-safe locations
+        # (wrapper uses /tmp/review_scope.txt + /tmp/review.diff by default)
+        repo_root = Path(__file__).parent.parent
+        wrapper = repo_root / "scripts" / "prepare-diff-scope"
+        result = subprocess.run([str(wrapper), "--ensure"], cwd=tmp, capture_output=True, text=True)
+        r.test("wrapper exits 0", result.returncode == 0,
+               f"rc={result.returncode} stderr={result.stderr}")
+        r.test("wrapper wrote scope file", Path("/tmp/review_scope.txt").exists(),
+               "scope file missing after wrapper run")
+```
+
+**Step 3: Run — expect 20/20 GREEN**
+
+```bash
+python3 hooks/test_diff_scope.py
+```
+
+**Step 4: Commit**
+
+```bash
+git add scripts/prepare-diff-scope hooks/test_diff_scope.py
+git commit -m "feat(scripts): add prepare-diff-scope bash wrapper"
+```
+
+---
+
+## Task 12: Migrate `/deep-review` to `diff_scope` helper
+
+**Files:**
+- Modify: `plugins/requirements-framework/commands/deep-review.md`
+
+**Step 1: Update frontmatter**
+
+```yaml
+---
+name: deep-review
+description: "Cross-validated team-based code review with agent debate"
+argument-hint: "[branch | a..b | PR#]"
+allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
+git_hash: uncommitted
+---
+```
+
+**Step 2: Replace Step 1 body**
+
+Find the current `### Step 1: Identify Changes to Review` section (around line 19-30). Replace its bash with:
+
+```bash
+scripts/prepare-diff-scope "$ARGUMENTS"
+```
+
+Add a paragraph: *"The wrapper writes `/tmp/review_scope.txt` (one file per line) and `/tmp/review.diff` (unified diff). If either is empty, output `No changes to review` and EXIT."*
+
+**Step 3: Update Step 5 teammate prompts to reference the new paths**
+
+In the "Standard preamble for ALL teammate prompts" block, ensure the prompt includes: *"SCOPE_FILE=/tmp/review_scope.txt DIFF_FILE=/tmp/review.diff"*.
+
+**Step 4: Deploy and sanity-check the command file**
+
+```bash
+./sync.sh deploy
+grep -c "git diff --cached" plugins/requirements-framework/commands/deep-review.md
+# Expected: 0 (the inline git diff lines should be gone)
+```
+
+**Step 5: Commit**
+
+```bash
+git add plugins/requirements-framework/commands/deep-review.md
+git commit -m "feat(commands): migrate /deep-review to diff_scope helper"
+```
+
+---
+
+## Task 13: Migrate `/quality-check` to `diff_scope` helper
+
+**Files:**
+- Modify: `plugins/requirements-framework/commands/quality-check.md`
+
+**Step 1: Read the current quality-check.md to locate its Step 1**
+
+```bash
+grep -n "git diff" plugins/requirements-framework/commands/quality-check.md
+```
+
+**Step 2: Apply the same Step 1 replacement as Task 12**
+
+Replace inline `git diff` with `scripts/prepare-diff-scope "$ARGUMENTS"` and update `argument-hint` to `"[branch | a..b | PR#]"`.
+
+**Step 3: Update any subagent prompts to reference `/tmp/review_scope.txt` + `/tmp/review.diff`**
+
+**Step 4: Deploy + verify**
+
+```bash
+./sync.sh deploy
+```
+
+**Step 5: Commit**
+
+```bash
+git add plugins/requirements-framework/commands/quality-check.md
+git commit -m "feat(commands): migrate /quality-check to diff_scope helper"
+```
+
+---
+
+## Task 14: Unify Step 1 across 13 review agents
+
+**Files (all 13):**
+- `plugins/requirements-framework/agents/code-reviewer.md`
+- `plugins/requirements-framework/agents/tool-validator.md`
+- `plugins/requirements-framework/agents/silent-failure-hunter.md`
+- `plugins/requirements-framework/agents/test-analyzer.md`
+- `plugins/requirements-framework/agents/type-design-analyzer.md`
+- `plugins/requirements-framework/agents/comment-analyzer.md`
+- `plugins/requirements-framework/agents/code-simplifier.md`
+- `plugins/requirements-framework/agents/backward-compatibility-checker.md`
+- `plugins/requirements-framework/agents/frontend-reviewer.md`
+- `plugins/requirements-framework/agents/codex-review-agent.md`
+- `plugins/requirements-framework/agents/tenant-isolation-auditor.md`
+- `plugins/requirements-framework/agents/appsec-auditor.md`
+- `plugins/requirements-framework/agents/compliance-auditor.md`
+
+**Step 1: For each agent, locate its existing Step 1**
+
+```bash
+for f in plugins/requirements-framework/agents/{code-reviewer,tool-validator,silent-failure-hunter,test-analyzer,type-design-analyzer,comment-analyzer,code-simplifier,backward-compatibility-checker,frontend-reviewer,codex-review-agent,tenant-isolation-auditor,appsec-auditor,compliance-auditor}.md; do
+  echo "=== $f ==="
+  grep -n "Step 1" "$f" | head -3
+done
+```
+
+**Step 2: Replace each existing Step 1 body with this canonical block**
+
+```markdown
+## Step 1: Load Review Scope
+
+Execute: `scripts/prepare-diff-scope --ensure`
+
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
+
+Focus your review on the files in the scope; do not expand beyond them.
+```
+
+Keep each agent's subsequent Steps 2+ intact.
+
+**Step 3: Ensure each agent has the right `allowed-tools` frontmatter**
+
+Required minimum for diff-based reviewers: `["Bash", "Read", "Glob", "Grep"]`.
+Add `"SendMessage", "TaskUpdate"` where the agent is used as a teammate (already present in most).
+
+**Step 4: Codex agent special-case**
+
+`codex-review-agent.md`: where it currently constructs its own diff via `git diff`, replace with reading `/tmp/review.diff` and passing the content to `codex exec` as context.
+
+**Step 5: Deploy + sanity grep**
+
+```bash
+./sync.sh deploy
+grep -l "git diff --cached\|git diff >\|git diff > /tmp" plugins/requirements-framework/agents/{code-reviewer,tool-validator,silent-failure-hunter,test-analyzer,type-design-analyzer,comment-analyzer,code-simplifier,backward-compatibility-checker,frontend-reviewer,codex-review-agent,tenant-isolation-auditor,appsec-auditor,compliance-auditor}.md
+# Expected: empty output — no agents still run git diff in Step 1
+```
+
+**Step 6: Run test suite**
+
+```bash
+python3 hooks/test_requirements.py
+python3 hooks/test_diff_scope.py
+# Expected: both green.
+```
+
+**Step 7: Commit**
+
+```bash
+git add plugins/requirements-framework/agents/
+git commit -m "refactor(agents): unify Step 1 on diff_scope helper (13 agents)"
+```
+
+---
+
+## Task 15: Plugin bump to 3.0.0 + CHANGELOG + plugin-version guard test
+
+**Files:**
+- Modify: `plugins/requirements-framework/.claude-plugin/plugin.json`
+- Create/Modify: `CHANGELOG.md` (repo root)
+- Modify: `hooks/test_diff_scope.py`
+
+**Step 1: Bump version**
+
+Edit `plugin.json`:
+
+```json
+{
+  "name": "requirements-framework",
+  "version": "3.0.0",
+  ...
+}
+```
+
+**Step 2: Write CHANGELOG entry**
+
+Create or prepend to `CHANGELOG.md`:
+
+```markdown
+## 3.0.0 — 2026-04-XX
+
+### Breaking
+- All 13 diff-based review agents now require `/tmp/review_scope.txt` and
+  `/tmp/review.diff` to be pre-computed (or use `scripts/prepare-diff-scope
+  --ensure` as fallback). Agents no longer run `git diff` in Step 1.
+- Consumers that invoke review agents directly via Task tool with a
+  custom pre-populated `/tmp/code_review.diff` must update to the new
+  paths.
+
+### Added
+- `hooks/lib/diff_scope.py` — unified review-scope resolution (branch,
+  range, PR number, empty).
+- `scripts/prepare-diff-scope` — bash wrapper invoked by commands and agents.
+- `hooks.diff_scope.base` config key (default `origin/master`).
+- `/deep-review` and `/quality-check` accept branch / range / PR# args.
+- `/arch-review` accepts a plan file path as argument.
+
+### Developer
+- New test file `hooks/test_diff_scope.py` with ~26 tests using fixture git repos.
+```
+
+**Step 3: Add plugin-version guard test**
+
+```python
+def test_plugin_version_bumped(r: TestRunner):
+    import json
+    repo_root = Path(__file__).parent.parent
+    manifest = repo_root / "plugins" / "requirements-framework" / ".claude-plugin" / "plugin.json"
+    diff_scope_py = repo_root / "hooks" / "lib" / "diff_scope.py"
+    if not diff_scope_py.exists():
+        r.test("version guard skipped (diff_scope absent)", True)
+        return
+    version = json.loads(manifest.read_text())["version"]
+    major = int(version.split(".")[0])
+    r.test("plugin version bumped to >= 3.0.0 when diff_scope present",
+           major >= 3, f"got version {version}")
+```
+
+**Step 4: Run tests — expect all GREEN**
+
+```bash
+python3 hooks/test_diff_scope.py
+python3 hooks/test_requirements.py
+```
+
+**Step 5: Commit**
+
+```bash
+git add plugins/requirements-framework/.claude-plugin/plugin.json CHANGELOG.md hooks/test_diff_scope.py
+git commit -m "chore: bump plugin to 3.0.0 + CHANGELOG + version guard test"
+```
+
+---
+
+## Task 16: `/arch-review` accepts plan file path argument
+
+**Files:**
+- Modify: `plugins/requirements-framework/commands/arch-review.md`
+
+**Step 1: Read current arch-review.md**
+
+```bash
+grep -n "argument-hint\|ARGUMENTS\|plan file" plugins/requirements-framework/commands/arch-review.md
+```
+
+**Step 2: Update frontmatter**
+
+```yaml
+argument-hint: "[plan-file-path]"
+```
+
+**Step 3: Add a Step 0 to resolve the plan file**
+
+Insert (near top of the command body):
+
+```markdown
+## Step 0: Resolve Plan File
+
+If `$ARGUMENTS` is provided, treat it as the plan file path. Verify it exists:
+
+```bash
+test -f "$ARGUMENTS" || { echo "Plan file not found: $ARGUMENTS"; exit 2; }
+```
+
+Otherwise, default to the most recent file in `docs/plans/*.md`:
+
+```bash
+ls -t docs/plans/*.md 2>/dev/null | head -1
+```
+
+Pass this plan path into all teammate prompts.
+```
+
+**Step 4: Deploy and manual-smoke**
+
+```bash
+./sync.sh deploy
+```
+
+**Step 5: Commit**
+
+```bash
+git add plugins/requirements-framework/commands/arch-review.md
+git commit -m "feat(commands): /arch-review accepts plan file path argument"
+```
+
+---
+
+## Post-implementation
+
+**Step 1: Run the full suite**
+
+```bash
+python3 hooks/test_requirements.py
+python3 hooks/test_diff_scope.py
+python3 hooks/test_branch_size_calculator.py
+```
+
+Expected: all three green.
+
+**Step 2: Update plugin versions metadata for changed files**
+
+```bash
+./update-plugin-versions.sh
+git add -u
+git commit -m "chore: update plugin component git_hash metadata"
+```
+
+**Step 3: Run `/arch-review docs/plans/2026-04-21-diff-scope-refactor-plan.md`**
+
+This re-satisfies the gates we bypassed earlier (commit_plan, adr_reviewed, tdd_planned, solid_reviewed) against the real plan.
+
+**Step 4: Run `/deep-review` before PR**
+
+```bash
+/deep-review
+```
+
+**Step 5: Open PR**
+
+```bash
+gh pr create --title "Diff scope refactor (plugin 3.0.0)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds hooks/lib/diff_scope.py as one source of truth for review scope
+- Adds scripts/prepare-diff-scope bash wrapper
+- Migrates /deep-review and /quality-check commands
+- Unifies Step 1 across 13 review agents
+- /arch-review now accepts plan file path argument
+- Breaking: agents no longer run their own git diff — bumps plugin to 3.0.0
+
+See docs/plans/2026-04-21-diff-scope-refactor-design.md for the full design.
+
+## Test plan
+- [ ] python3 hooks/test_diff_scope.py (26+ tests)
+- [ ] python3 hooks/test_requirements.py (existing suite)
+- [ ] /deep-review feat/diff-scope-refactor (dogfood)
+- [ ] /deep-review 1234 (new PR# path) against a real PR
+- [ ] scripts/prepare-diff-scope master..HEAD (range path)
+EOF
+)"
+```
+
+---
+
+## Open items (carried over from design)
+
+- Task #7 in brainstorming session: review `comment-cleaner` + `import-organizer` for inclusion in a future staged-scope helper
+- Consider writing ADR-014 for the 3.0.0 agent-contract break (decide after Task 15)
+
+---
+
+## Test count summary
+
+| Group | Tests | After Task |
+|---|---|---|
+| Empty-arg precedence | 5 | 2 |
+| Branch arg | 3 | 4 |
+| Range arg | 3 | 4 |
+| PR# arg | 4 | 6 |
+| Scope dataclass / file outputs | 2 | 3 |
+| Config override | 2 | 8 |
+| ensure_scope fallback | 2 | 9 |
+| Wrapper smoke | 1 | 11 |
+| Plugin version guard | 1 | 15 |
+| **Total** | **23** | end |
+
+Design called for ~26 — gaps we may add opportunistically: large-diff warning test, idempotent overwrite test, custom-paths test. These can land within Task 11 or Task 15 without separate commits.

--- a/hooks/lib/diff_scope.py
+++ b/hooks/lib/diff_scope.py
@@ -241,3 +241,22 @@ def ensure_scope(
 ) -> Scope:
     """Agent entry: read pre-computed if present, else compute."""
     raise NotImplementedError
+
+
+def base_from_config(project_dir: str | None = None) -> str:
+    """Read hooks.diff_scope.base from the config cascade.
+
+    Falls back to DEFAULT_BASE on any error. Config failures must never
+    break scope resolution.
+    """
+    try:
+        # Lazy imports: config stack may be unavailable in minimal environments.
+        from config import RequirementsConfig  # noqa: WPS433
+        from git_utils import resolve_project_root  # noqa: WPS433
+
+        root = project_dir or resolve_project_root(verbose=False)
+        cfg = RequirementsConfig(root)
+        value = cfg.get_hook_config("diff_scope", "base", DEFAULT_BASE)
+        return value if isinstance(value, str) and value else DEFAULT_BASE
+    except Exception:
+        return DEFAULT_BASE

--- a/hooks/lib/diff_scope.py
+++ b/hooks/lib/diff_scope.py
@@ -232,15 +232,30 @@ def read_scope(
     diff_file: Path = DEFAULT_DIFF_FILE,
 ) -> Scope:
     """Read pre-computed scope without re-resolving."""
-    raise NotImplementedError
+    files = (
+        [line for line in scope_file.read_text().splitlines() if line]
+        if scope_file.exists()
+        else []
+    )
+    diff_text = diff_file.read_text() if diff_file.exists() else ""
+    return Scope(
+        files=files,
+        diff_text=diff_text,
+        scope_file=scope_file,
+        diff_file=diff_file,
+        source="precomputed",
+        base_ref=None,
+    )
 
 
 def ensure_scope(
     scope_file: Path = DEFAULT_SCOPE_FILE,
     diff_file: Path = DEFAULT_DIFF_FILE,
 ) -> Scope:
-    """Agent entry: read pre-computed if present, else compute."""
-    raise NotImplementedError
+    """Agent entry: read pre-computed scope if present, else compute."""
+    if scope_file.exists() and diff_file.exists() and scope_file.stat().st_size > 0:
+        return read_scope(scope_file, diff_file)
+    return prepare_diff_scope(None, scope_file=scope_file, diff_file=diff_file)
 
 
 def base_from_config(project_dir: str | None = None) -> str:

--- a/hooks/lib/diff_scope.py
+++ b/hooks/lib/diff_scope.py
@@ -12,6 +12,7 @@ See docs/plans/2026-04-21-diff-scope-refactor-design.md.
 """
 from __future__ import annotations
 
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -26,6 +27,8 @@ DEFAULT_SCOPE_FILE = Path("/tmp/review_scope.txt")
 DEFAULT_DIFF_FILE = Path("/tmp/review.diff")
 DEFAULT_BASE = "origin/master"
 LARGE_DIFF_BYTES = 1_000_000  # 1 MB — warn but don't truncate
+
+_RANGE_RE = re.compile(r"^[^.\s]+\.{2,3}[^.\s]+$")
 
 
 _log = get_logger()
@@ -106,6 +109,38 @@ def _resolve_empty(base: str) -> tuple[list[str], str, str, str | None]:
     return files, diff_text, f"branch:{branch}", base
 
 
+def _classify_arg(arg: str) -> str:
+    """Return 'range', 'pr', or 'branch' based on shape."""
+    if _RANGE_RE.match(arg):
+        return "range"
+    if arg.lstrip("#").isdigit():
+        return "pr"
+    return "branch"
+
+
+def _resolve_branch(branch: str, base: str) -> tuple[list[str], str, str, str | None]:
+    code, _, _ = run_git(f"git rev-parse --verify {branch}")
+    if code != 0:
+        raise DiffScopeError(f"branch '{branch}' not found")
+    # Validate base ref too (consistent with _resolve_empty)
+    verify_code, _, _ = run_git(f"git rev-parse --verify {base}")
+    if verify_code != 0:
+        raise DiffScopeError(f"base ref not found: {base}")
+    code, names, _ = run_git(f"git diff --name-only {base}...{branch}")
+    files = [line for line in names.splitlines() if line] if code == 0 else []
+    _, diff_text, _ = run_git(f"git diff {base}...{branch}")
+    return files, diff_text, f"branch:{branch}", base
+
+
+def _resolve_range(rng: str) -> tuple[list[str], str, str, str | None]:
+    code, names, err = run_git(f"git diff --name-only {rng}")
+    if code != 0:
+        raise DiffScopeError(f"invalid range '{rng}': {err}")
+    files = [line for line in names.splitlines() if line]
+    _, diff_text, _ = run_git(f"git diff {rng}")
+    return files, diff_text, f"range:{rng}", None
+
+
 def prepare_diff_scope(
     arg: str | None = None,
     scope_file: Path = DEFAULT_SCOPE_FILE,
@@ -128,7 +163,26 @@ def prepare_diff_scope(
             base_ref=base_ref,
         )
 
-    raise NotImplementedError(f"arg not yet supported: {arg!r}")
+    # Non-empty arg: classify and dispatch
+    kind = _classify_arg(arg)
+    if kind == "range":
+        files, diff_text, source, base_ref = _resolve_range(arg)
+    elif kind == "branch":
+        files, diff_text, source, base_ref = _resolve_branch(arg, base)
+    elif kind == "pr":
+        raise NotImplementedError("pr support in next task")
+    else:
+        raise DiffScopeError(f"unrecognized arg: {arg!r}")
+
+    _write_scope_files(files, diff_text, scope_file, diff_file)
+    return Scope(
+        files=files,
+        diff_text=diff_text,
+        scope_file=scope_file,
+        diff_file=diff_file,
+        source=source,
+        base_ref=base_ref,
+    )
 
 
 def read_scope(

--- a/hooks/lib/diff_scope.py
+++ b/hooks/lib/diff_scope.py
@@ -13,6 +13,8 @@ See docs/plans/2026-04-21-diff-scope-refactor-design.md.
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -141,6 +143,46 @@ def _resolve_range(rng: str) -> tuple[list[str], str, str, str | None]:
     return files, diff_text, f"range:{rng}", None
 
 
+def _parse_diff_files(diff_text: str) -> list[str]:
+    """Extract changed file paths from a unified diff (+++ b/... lines)."""
+    files: list[str] = []
+    for line in diff_text.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[6:].strip()
+            if path and path != "/dev/null":
+                files.append(path)
+    return files
+
+
+def _resolve_pr(pr_num: str) -> tuple[list[str], str, str, str | None]:
+    if shutil.which("gh") is None:
+        raise DiffScopeError(
+            "gh CLI required for PR# argument. Install: https://cli.github.com/"
+        )
+    num = pr_num.lstrip("#")
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "diff", num, "--patch"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        raise DiffScopeError(f"gh pr diff {num} timed out")
+
+    if result.returncode != 0:
+        combined = (result.stdout + "\n" + result.stderr).lower()
+        if "could not resolve" in combined or "not found" in combined:
+            raise DiffScopeError(f"PR #{num} not found or access denied")
+        raise DiffScopeError(
+            f"gh pr diff {num} failed: {result.stderr.strip() or result.stdout.strip()}"
+        )
+
+    diff_text = result.stdout
+    files = _parse_diff_files(diff_text)
+    return files, diff_text, f"pr:{num}", None
+
+
 def prepare_diff_scope(
     arg: str | None = None,
     scope_file: Path = DEFAULT_SCOPE_FILE,
@@ -170,7 +212,7 @@ def prepare_diff_scope(
     elif kind == "branch":
         files, diff_text, source, base_ref = _resolve_branch(arg, base)
     elif kind == "pr":
-        raise NotImplementedError("pr support in next task")
+        files, diff_text, source, base_ref = _resolve_pr(arg)
     else:
         raise DiffScopeError(f"unrecognized arg: {arg!r}")
 

--- a/hooks/lib/diff_scope.py
+++ b/hooks/lib/diff_scope.py
@@ -12,14 +12,23 @@ See docs/plans/2026-04-21-diff-scope-refactor-design.md.
 """
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+
+# Import run_git from the same lib directory
+sys.path.insert(0, str(Path(__file__).parent))
+from git_utils import run_git  # noqa: E402
+from logger import get_logger  # noqa: E402
 
 
 DEFAULT_SCOPE_FILE = Path("/tmp/review_scope.txt")
 DEFAULT_DIFF_FILE = Path("/tmp/review.diff")
 DEFAULT_BASE = "origin/master"
 LARGE_DIFF_BYTES = 1_000_000  # 1 MB — warn but don't truncate
+
+
+_log = get_logger()
 
 
 class DiffScopeError(Exception):
@@ -36,6 +45,67 @@ class Scope:
     base_ref: str | None = None    # ref we diffed against
 
 
+def _is_git_repo(cwd: str | None = None) -> bool:
+    code, _, _ = run_git("git rev-parse --git-dir", cwd=cwd)
+    return code == 0
+
+
+def _write_scope_files(
+    files: list[str],
+    diff_text: str,
+    scope_file: Path,
+    diff_file: Path,
+) -> None:
+    scope_file.write_text("\n".join(files) + ("\n" if files else ""))
+    diff_file.write_text(diff_text)
+    if len(diff_text) > LARGE_DIFF_BYTES:
+        _log.warning(
+            f"review diff exceeds {LARGE_DIFF_BYTES} bytes ({len(diff_text)} bytes)"
+        )
+
+
+def _resolve_empty(base: str) -> tuple[list[str], str, str, str | None]:
+    """Return (files, diff_text, source, base_ref) for empty arg."""
+    # Staged
+    code, staged_names, _ = run_git("git diff --cached --name-only --diff-filter=ACMRD")
+    if code == 0 and staged_names:
+        files = [line for line in staged_names.splitlines() if line]
+        _, diff_text, _ = run_git("git diff --cached")
+        return files, diff_text, "staged", None
+
+    # Unstaged (modified tracked files + untracked files)
+    _, un_names, _ = run_git("git diff --name-only --diff-filter=ACMRD")
+    _, untracked, _ = run_git("git ls-files --others --exclude-standard")
+    un_files = [line for line in un_names.splitlines() if line]
+    untracked_files = [line for line in untracked.splitlines() if line]
+    # Preserve order: modified first, then untracked, deduped.
+    seen: set[str] = set()
+    files: list[str] = []
+    for name in un_files + untracked_files:
+        if name not in seen:
+            seen.add(name)
+            files.append(name)
+    if files:
+        _, diff_text, _ = run_git("git diff")
+        return files, diff_text, "unstaged", None
+
+    # Branch vs base
+    code, branch, _ = run_git("git symbolic-ref --short HEAD")
+    if code != 0 or not branch:
+        # Detached HEAD — fall back to SHA
+        _, sha, _ = run_git("git rev-parse HEAD")
+        branch = sha
+
+    verify_code, _, _ = run_git(f"git rev-parse --verify {base}")
+    if verify_code != 0:
+        raise DiffScopeError(f"base ref not found: {base}")
+
+    code, names, _ = run_git(f"git diff --name-only {base}...HEAD")
+    files = [line for line in names.splitlines() if line] if code == 0 else []
+    _, diff_text, _ = run_git(f"git diff {base}...HEAD")
+    return files, diff_text, f"branch:{branch}", base
+
+
 def prepare_diff_scope(
     arg: str | None = None,
     scope_file: Path = DEFAULT_SCOPE_FILE,
@@ -43,7 +113,22 @@ def prepare_diff_scope(
     base: str = DEFAULT_BASE,
 ) -> Scope:
     """Resolve `arg` to a Scope and write both files. See module docstring."""
-    raise NotImplementedError
+    if not _is_git_repo():
+        raise DiffScopeError("not a git repository")
+
+    if not arg:
+        files, diff_text, source, base_ref = _resolve_empty(base)
+        _write_scope_files(files, diff_text, scope_file, diff_file)
+        return Scope(
+            files=files,
+            diff_text=diff_text,
+            scope_file=scope_file,
+            diff_file=diff_file,
+            source=source,
+            base_ref=base_ref,
+        )
+
+    raise NotImplementedError(f"arg not yet supported: {arg!r}")
 
 
 def read_scope(

--- a/hooks/lib/diff_scope.py
+++ b/hooks/lib/diff_scope.py
@@ -1,0 +1,62 @@
+# hooks/lib/diff_scope.py
+#!/usr/bin/env python3
+"""
+Review scope resolution for diff-based review agents and commands.
+
+Resolves a user-supplied argument (branch name, git range, PR number,
+or empty) to a concrete set of changed files and a unified diff, and
+writes them to predictable paths so downstream agents don't re-run
+git diff themselves.
+
+See docs/plans/2026-04-21-diff-scope-refactor-design.md.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+DEFAULT_SCOPE_FILE = Path("/tmp/review_scope.txt")
+DEFAULT_DIFF_FILE = Path("/tmp/review.diff")
+DEFAULT_BASE = "origin/master"
+LARGE_DIFF_BYTES = 1_000_000  # 1 MB — warn but don't truncate
+
+
+class DiffScopeError(Exception):
+    """Raised when scope cannot be resolved (bad input, missing gh, etc.)."""
+
+
+@dataclass(frozen=True)
+class Scope:
+    files: list[str] = field(default_factory=list)
+    diff_text: str = ""
+    scope_file: Path = DEFAULT_SCOPE_FILE
+    diff_file: Path = DEFAULT_DIFF_FILE
+    source: str = "empty"          # "empty" | "staged" | "unstaged" | "branch:X" | "range:a..b" | "pr:N"
+    base_ref: str | None = None    # ref we diffed against
+
+
+def prepare_diff_scope(
+    arg: str | None = None,
+    scope_file: Path = DEFAULT_SCOPE_FILE,
+    diff_file: Path = DEFAULT_DIFF_FILE,
+    base: str = DEFAULT_BASE,
+) -> Scope:
+    """Resolve `arg` to a Scope and write both files. See module docstring."""
+    raise NotImplementedError
+
+
+def read_scope(
+    scope_file: Path = DEFAULT_SCOPE_FILE,
+    diff_file: Path = DEFAULT_DIFF_FILE,
+) -> Scope:
+    """Read pre-computed scope without re-resolving."""
+    raise NotImplementedError
+
+
+def ensure_scope(
+    scope_file: Path = DEFAULT_SCOPE_FILE,
+    diff_file: Path = DEFAULT_DIFF_FILE,
+) -> Scope:
+    """Agent entry: read pre-computed if present, else compute."""
+    raise NotImplementedError

--- a/hooks/test_diff_scope.py
+++ b/hooks/test_diff_scope.py
@@ -366,6 +366,46 @@ def test_pr_gh_not_authed(r: TestRunner):
             os.environ["PATH"] = old_path
 
 
+# --- Tests: config override --------------------------------------------------
+
+def test_config_override_applied(r: TestRunner):
+    """Explicit base= parameter threads through to Scope.base_ref."""
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        _run(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], cwd=tmp)
+        _run(["git", "checkout", "-b", "feat/x"], cwd=tmp)
+        write_and_stage(tmp, "z.py", "z\n")
+        _run(["git", "commit", "-m", "z"], cwd=tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope(
+            None,
+            base="origin/main",
+            scope_file=Path(tmp) / "scope.txt",
+            diff_file=Path(tmp) / "review.diff",
+        )
+        r.test("explicit base override threaded through",
+               scope.base_ref == "origin/main",
+               f"got {scope.base_ref}")
+
+
+def test_config_default_used(r: TestRunner):
+    """When no base is passed, DEFAULT_BASE is used."""
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        _run(["git", "checkout", "-b", "feat/x"], cwd=tmp)
+        write_and_stage(tmp, "z.py", "z\n")
+        _run(["git", "commit", "-m", "z"], cwd=tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope(
+            None,
+            scope_file=Path(tmp) / "scope.txt",
+            diff_file=Path(tmp) / "review.diff",
+        )
+        r.test("default base used when not overridden",
+               scope.base_ref == DEFAULT_BASE,
+               f"got {scope.base_ref}")
+
+
 def main():
     runner = TestRunner()
     print("Empty-arg precedence:")
@@ -392,6 +432,10 @@ def main():
     test_pr_gh_succeeds(runner)
     test_pr_gh_not_found(runner)
     test_pr_gh_not_authed(runner)
+
+    print("\nConfig override:")
+    test_config_override_applied(runner)
+    test_config_default_used(runner)
     sys.exit(runner.summary())
 
 

--- a/hooks/test_diff_scope.py
+++ b/hooks/test_diff_scope.py
@@ -406,6 +406,54 @@ def test_config_default_used(r: TestRunner):
                f"got {scope.base_ref}")
 
 
+# --- Tests: ensure_scope fallback --------------------------------------------
+
+def test_ensure_scope_uses_precomputed(r: TestRunner):
+    """ensure_scope reads pre-existing files without re-running git diff."""
+    with tempfile.TemporaryDirectory() as tmp:
+        scope_f = Path(tmp) / "scope.txt"
+        diff_f = Path(tmp) / "review.diff"
+        scope_f.write_text("a.py\nb.py\n")
+        diff_f.write_text("fake diff content\n")
+        try:
+            scope = ensure_scope(scope_file=scope_f, diff_file=diff_f)
+            r.test("ensure reads precomputed files",
+                   scope.files == ["a.py", "b.py"],
+                   f"got {scope.files}")
+            r.test("ensure reads diff text",
+                   "fake diff" in scope.diff_text,
+                   "diff content not read")
+        except NotImplementedError as e:
+            r.test("ensure reads precomputed files", False,
+                   f"RED: got NotImplementedError: {e}")
+            r.test("ensure reads diff text", False,
+                   f"RED: got NotImplementedError: {e}")
+
+
+def test_ensure_scope_computes_on_demand(r: TestRunner):
+    """ensure_scope falls back to prepare_diff_scope(None) when files absent."""
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        write_and_stage(tmp, "x.py", "x\n")
+        os.chdir(tmp)
+        scope_f = Path(tmp) / "scope.txt"
+        diff_f = Path(tmp) / "review.diff"
+        # Files don't exist yet
+        try:
+            scope = ensure_scope(scope_file=scope_f, diff_file=diff_f)
+            r.test("ensure falls back to prepare when files absent",
+                   scope.files == ["x.py"],
+                   f"got {scope.files}")
+            r.test("ensure wrote files during fallback",
+                   scope_f.exists() and diff_f.exists(),
+                   "files not written")
+        except NotImplementedError as e:
+            r.test("ensure falls back to prepare when files absent", False,
+                   f"RED: got NotImplementedError: {e}")
+            r.test("ensure wrote files during fallback", False,
+                   f"RED: got NotImplementedError: {e}")
+
+
 def main():
     runner = TestRunner()
     print("Empty-arg precedence:")
@@ -436,6 +484,10 @@ def main():
     print("\nConfig override:")
     test_config_override_applied(runner)
     test_config_default_used(runner)
+
+    print("\nEnsure scope fallback:")
+    test_ensure_scope_uses_precomputed(runner)
+    test_ensure_scope_computes_on_demand(runner)
     sys.exit(runner.summary())
 
 

--- a/hooks/test_diff_scope.py
+++ b/hooks/test_diff_scope.py
@@ -457,7 +457,7 @@ def test_ensure_scope_computes_on_demand(r: TestRunner):
 # --- Tests: wrapper script integration ---------------------------------------
 
 def test_wrapper_smoke(r: TestRunner):
-    """scripts/prepare-diff-scope --ensure writes expected files from a fixture repo."""
+    """plugins/requirements-framework/scripts/prepare-diff-scope --ensure writes expected files."""
     with tempfile.TemporaryDirectory() as tmp:
         make_repo(tmp)
         write_and_stage(tmp, "smoke.py", "smoke\n")
@@ -470,7 +470,7 @@ def test_wrapper_smoke(r: TestRunner):
                 pass
         os.chdir(tmp)
         repo_root = Path(__file__).parent.parent
-        wrapper = repo_root / "scripts" / "prepare-diff-scope"
+        wrapper = repo_root / "plugins" / "requirements-framework" / "scripts" / "prepare-diff-scope"
         result = subprocess.run(
             [str(wrapper), "--ensure"],
             cwd=tmp,

--- a/hooks/test_diff_scope.py
+++ b/hooks/test_diff_scope.py
@@ -454,6 +454,37 @@ def test_ensure_scope_computes_on_demand(r: TestRunner):
                    f"RED: got NotImplementedError: {e}")
 
 
+# --- Tests: wrapper script integration ---------------------------------------
+
+def test_wrapper_smoke(r: TestRunner):
+    """scripts/prepare-diff-scope --ensure writes expected files from a fixture repo."""
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        write_and_stage(tmp, "smoke.py", "smoke\n")
+        # Wrapper writes to /tmp/review_scope.txt + /tmp/review.diff by default.
+        # Clear them first so we actually exercise the fallback path.
+        for default in ("/tmp/review_scope.txt", "/tmp/review.diff"):
+            try:
+                Path(default).unlink()
+            except FileNotFoundError:
+                pass
+        os.chdir(tmp)
+        repo_root = Path(__file__).parent.parent
+        wrapper = repo_root / "scripts" / "prepare-diff-scope"
+        result = subprocess.run(
+            [str(wrapper), "--ensure"],
+            cwd=tmp,
+            capture_output=True,
+            text=True,
+        )
+        r.test("wrapper exits 0",
+               result.returncode == 0,
+               f"rc={result.returncode} stderr={result.stderr}")
+        r.test("wrapper wrote /tmp/review_scope.txt",
+               Path("/tmp/review_scope.txt").exists(),
+               "scope file missing after wrapper run")
+
+
 def main():
     runner = TestRunner()
     print("Empty-arg precedence:")
@@ -488,6 +519,9 @@ def main():
     print("\nEnsure scope fallback:")
     test_ensure_scope_uses_precomputed(runner)
     test_ensure_scope_computes_on_demand(runner)
+
+    print("\nWrapper integration:")
+    test_wrapper_smoke(runner)
     sys.exit(runner.summary())
 
 

--- a/hooks/test_diff_scope.py
+++ b/hooks/test_diff_scope.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Test Suite for diff_scope module.
+
+Tests follow the framework's TestRunner convention (see test_branch_size_calculator.py).
+Uses real git repos in tempdirs — no subprocess mocking except for `gh` CLI.
+
+Run with: python3 hooks/test_diff_scope.py
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Add lib directory to path
+lib_path = Path(__file__).parent / "lib"
+sys.path.insert(0, str(lib_path))
+
+from diff_scope import (
+    DEFAULT_BASE,
+    DEFAULT_DIFF_FILE,
+    DEFAULT_SCOPE_FILE,
+    DiffScopeError,
+    Scope,
+    ensure_scope,
+    prepare_diff_scope,
+    read_scope,
+)
+
+
+class TestRunner:
+    def __init__(self):
+        self.passed = 0
+        self.failed = 0
+        self.failed_tests = []
+
+    def test(self, name: str, condition: bool, msg: str = ""):
+        if condition:
+            print(f"  ✅ {name}")
+            self.passed += 1
+        else:
+            print(f"  ❌ {name}: {msg}")
+            self.failed += 1
+            self.failed_tests.append((name, msg))
+
+    def summary(self):
+        total = self.passed + self.failed
+        print(f"\n{'=' * 60}")
+        print(f"Results: {self.passed}/{total} passed")
+        if self.failed_tests:
+            print("\nFailed:")
+            for name, msg in self.failed_tests:
+                print(f"  • {name}: {msg}")
+        return 0 if self.failed == 0 else 1
+
+
+# --- Fixture helpers ---------------------------------------------------------
+
+def _run(cmd: list[str], cwd: str, check: bool = True) -> subprocess.CompletedProcess:
+    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        raise RuntimeError(f"{' '.join(cmd)} failed: {result.stderr}")
+    return result
+
+
+def make_repo(tmpdir: str) -> None:
+    """Init a git repo with one initial commit on `master`."""
+    _run(["git", "init", "-b", "master"], cwd=tmpdir)
+    _run(["git", "config", "user.email", "test@test.com"], cwd=tmpdir)
+    _run(["git", "config", "user.name", "Test"], cwd=tmpdir)
+    Path(tmpdir, "README.md").write_text("base\n")
+    _run(["git", "add", "."], cwd=tmpdir)
+    _run(["git", "commit", "-m", "initial"], cwd=tmpdir)
+    # Create origin/master ref locally so tests can diff against it
+    _run(["git", "update-ref", "refs/remotes/origin/master", "HEAD"], cwd=tmpdir)
+
+
+def write_and_stage(tmpdir: str, path: str, content: str) -> None:
+    Path(tmpdir, path).write_text(content)
+    _run(["git", "add", path], cwd=tmpdir)
+
+
+def write_unstaged(tmpdir: str, path: str, content: str) -> None:
+    Path(tmpdir, path).write_text(content)
+
+
+# --- Tests: empty-arg precedence ---------------------------------------------
+
+def test_empty_arg_staged_wins(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        write_and_stage(tmp, "a.py", "print('staged')\n")
+        write_unstaged(tmp, "b.py", "print('unstaged')\n")
+        os.chdir(tmp)
+        scope = prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("empty arg prefers staged", scope.source == "staged",
+               f"expected source=staged, got {scope.source}")
+        r.test("empty arg staged files correct", scope.files == ["a.py"],
+               f"expected ['a.py'], got {scope.files}")
+
+
+def test_empty_arg_unstaged_fallback(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        write_unstaged(tmp, "b.py", "print('unstaged')\n")
+        os.chdir(tmp)
+        scope = prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("empty arg uses unstaged when no staged", scope.source == "unstaged",
+               f"got source={scope.source}")
+
+
+def test_empty_arg_branch_vs_base(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        _run(["git", "checkout", "-b", "feat/x"], cwd=tmp)
+        write_and_stage(tmp, "c.py", "print('on branch')\n")
+        _run(["git", "commit", "-m", "feat"], cwd=tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("empty arg falls back to branch vs base", scope.source.startswith("branch:"),
+               f"got source={scope.source}")
+
+
+def test_empty_arg_detached_head(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        write_and_stage(tmp, "c.py", "content\n")
+        _run(["git", "commit", "-m", "second"], cwd=tmp)
+        sha = _run(["git", "rev-parse", "HEAD"], cwd=tmp).stdout.strip()
+        _run(["git", "checkout", sha], cwd=tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("detached HEAD resolves to branch-like diff", scope.files != [],
+               "detached HEAD should still produce a scope")
+
+
+def test_non_git_dir_raises(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        os.chdir(tmp)
+        try:
+            prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+            r.test("non-git raises DiffScopeError", False, "no exception raised")
+        except DiffScopeError as e:
+            r.test("non-git raises DiffScopeError", "not a git repository" in str(e).lower(),
+                   f"wrong message: {e}")
+
+
+def main():
+    runner = TestRunner()
+    print("Empty-arg precedence:")
+    test_empty_arg_staged_wins(runner)
+    test_empty_arg_unstaged_fallback(runner)
+    test_empty_arg_branch_vs_base(runner)
+    test_empty_arg_detached_head(runner)
+    test_non_git_dir_raises(runner)
+    sys.exit(runner.summary())
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/test_diff_scope.py
+++ b/hooks/test_diff_scope.py
@@ -181,6 +181,85 @@ def test_empty_arg_missing_base_raises(r: TestRunner):
                    f"got: {e}")
 
 
+# --- Tests: branch arg ------------------------------------------------------
+
+def test_branch_arg_valid(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        _run(["git", "checkout", "-b", "feat/x"], cwd=tmp)
+        write_and_stage(tmp, "c.py", "print('new')\n")
+        _run(["git", "commit", "-m", "feat"], cwd=tmp)
+        _run(["git", "checkout", "master"], cwd=tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope("feat/x", scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("branch arg source correct", scope.source == "branch:feat/x",
+               f"got source={scope.source}")
+        r.test("branch arg files correct", "c.py" in scope.files,
+               f"got files={scope.files}")
+
+
+def test_branch_arg_not_found(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        os.chdir(tmp)
+        try:
+            prepare_diff_scope("nonexistent")
+            r.test("branch not-found raises", False, "no exception")
+        except DiffScopeError as e:
+            r.test("branch not-found raises", "not found" in str(e).lower(),
+                   f"wrong message: {e}")
+
+
+def test_branch_arg_identical_to_base(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope("master", scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("identical branch returns empty scope", scope.files == [],
+               f"expected empty, got {scope.files}")
+
+
+# --- Tests: range arg --------------------------------------------------------
+
+def test_range_arg_two_dot(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        a = _run(["git", "rev-parse", "HEAD"], cwd=tmp).stdout.strip()
+        write_and_stage(tmp, "x.py", "x\n")
+        _run(["git", "commit", "-m", "x"], cwd=tmp)
+        b = _run(["git", "rev-parse", "HEAD"], cwd=tmp).stdout.strip()
+        os.chdir(tmp)
+        scope = prepare_diff_scope(f"{a}..{b}", scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("two-dot range resolves", scope.source.startswith("range:"),
+               f"got source={scope.source}")
+        r.test("two-dot range files", "x.py" in scope.files,
+               f"got files={scope.files}")
+
+
+def test_range_arg_three_dot(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        a = _run(["git", "rev-parse", "HEAD"], cwd=tmp).stdout.strip()
+        write_and_stage(tmp, "y.py", "y\n")
+        _run(["git", "commit", "-m", "y"], cwd=tmp)
+        b = _run(["git", "rev-parse", "HEAD"], cwd=tmp).stdout.strip()
+        os.chdir(tmp)
+        scope = prepare_diff_scope(f"{a}...{b}", scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("three-dot range resolves", scope.source.startswith("range:"),
+               f"got source={scope.source}")
+
+
+def test_range_arg_malformed(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        os.chdir(tmp)
+        try:
+            prepare_diff_scope("bad..junk..ref")
+            r.test("malformed range raises", False, "no exception")
+        except DiffScopeError:
+            r.test("malformed range raises", True)
+
+
 def main():
     runner = TestRunner()
     print("Empty-arg precedence:")
@@ -191,6 +270,16 @@ def main():
     test_non_git_dir_raises(runner)
     test_empty_arg_staged_deletion_included(runner)
     test_empty_arg_missing_base_raises(runner)
+
+    print("\nBranch arg:")
+    test_branch_arg_valid(runner)
+    test_branch_arg_not_found(runner)
+    test_branch_arg_identical_to_base(runner)
+
+    print("\nRange arg:")
+    test_range_arg_two_dot(runner)
+    test_range_arg_three_dot(runner)
+    test_range_arg_malformed(runner)
     sys.exit(runner.summary())
 
 

--- a/hooks/test_diff_scope.py
+++ b/hooks/test_diff_scope.py
@@ -485,6 +485,26 @@ def test_wrapper_smoke(r: TestRunner):
                "scope file missing after wrapper run")
 
 
+# --- Tests: plugin version guard ---------------------------------------------
+
+def test_plugin_version_bumped(r: TestRunner):
+    """If diff_scope.py exists, plugin.json major version must be >= 3."""
+    import json
+    repo_root = Path(__file__).parent.parent
+    manifest = repo_root / "plugins" / "requirements-framework" / ".claude-plugin" / "plugin.json"
+    diff_scope_py = repo_root / "hooks" / "lib" / "diff_scope.py"
+    if not diff_scope_py.exists():
+        r.test("version guard skipped (diff_scope absent)", True)
+        return
+    version = json.loads(manifest.read_text())["version"]
+    major = int(version.split(".")[0])
+    r.test(
+        "plugin version >= 3.0.0 when diff_scope present",
+        major >= 3,
+        f"got version {version}",
+    )
+
+
 def main():
     runner = TestRunner()
     print("Empty-arg precedence:")
@@ -522,6 +542,9 @@ def main():
 
     print("\nWrapper integration:")
     test_wrapper_smoke(runner)
+
+    print("\nPlugin version guard:")
+    test_plugin_version_bumped(runner)
     sys.exit(runner.summary())
 
 

--- a/hooks/test_diff_scope.py
+++ b/hooks/test_diff_scope.py
@@ -147,6 +147,40 @@ def test_non_git_dir_raises(r: TestRunner):
                    f"wrong message: {e}")
 
 
+def test_empty_arg_staged_deletion_included(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        # add and commit a file that will later be deleted
+        write_and_stage(tmp, "gone.py", "content\n")
+        _run(["git", "commit", "-m", "add gone.py"], cwd=tmp)
+        # Stage its deletion
+        _run(["git", "rm", "gone.py"], cwd=tmp)
+        os.chdir(tmp)
+        scope = prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+        r.test("staged deletion included in scope", "gone.py" in scope.files,
+               f"expected gone.py in files, got {scope.files}")
+        r.test("staged deletion keeps source=staged", scope.source == "staged",
+               f"got source={scope.source}")
+
+
+def test_empty_arg_missing_base_raises(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        # make_repo creates origin/master; delete it so base is missing
+        make_repo(tmp)
+        _run(["git", "update-ref", "-d", "refs/remotes/origin/master"], cwd=tmp)
+        _run(["git", "checkout", "-b", "feat/x"], cwd=tmp)
+        write_and_stage(tmp, "c.py", "content\n")
+        _run(["git", "commit", "-m", "feat"], cwd=tmp)
+        os.chdir(tmp)
+        try:
+            prepare_diff_scope(None, scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+            r.test("missing base ref raises", False, "no exception")
+        except DiffScopeError as e:
+            r.test("missing base ref raises with message",
+                   "base ref" in str(e).lower() or "not found" in str(e).lower(),
+                   f"got: {e}")
+
+
 def main():
     runner = TestRunner()
     print("Empty-arg precedence:")
@@ -155,6 +189,8 @@ def main():
     test_empty_arg_branch_vs_base(runner)
     test_empty_arg_detached_head(runner)
     test_non_git_dir_raises(runner)
+    test_empty_arg_staged_deletion_included(runner)
+    test_empty_arg_missing_base_raises(runner)
     sys.exit(runner.summary())
 
 

--- a/hooks/test_diff_scope.py
+++ b/hooks/test_diff_scope.py
@@ -260,6 +260,112 @@ def test_range_arg_malformed(r: TestRunner):
             r.test("malformed range raises", True)
 
 
+# --- Tests: PR# arg ----------------------------------------------------------
+
+def _install_fake_gh(tmp: str, stdout: str, exit_code: int) -> str:
+    """Create a fake gh binary that prints `stdout` and exits `exit_code`.
+
+    Returns the bin directory path to prepend to PATH.
+    """
+    bin_dir = Path(tmp) / "fakebin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    # Use a here-doc-esque approach so the fake gh prints exactly `stdout`.
+    # We write the stdout to a sidecar file and have the gh script cat it,
+    # which avoids shell-escaping headaches for diffs containing quotes.
+    out_file = bin_dir / "stdout.txt"
+    out_file.write_text(stdout)
+    gh.write_text(
+        "#!/bin/bash\n"
+        f"cat {out_file}\n"
+        f"exit {exit_code}\n"
+    )
+    gh.chmod(0o755)
+    return str(bin_dir)
+
+
+def test_pr_gh_missing(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        os.chdir(tmp)
+        old_path = os.environ.get("PATH", "")
+        # PATH without any gh
+        os.environ["PATH"] = "/usr/bin:/bin"
+        try:
+            prepare_diff_scope("1234")
+            r.test("gh missing raises", False, "no exception")
+        except DiffScopeError as e:
+            msg = str(e).lower()
+            r.test("gh missing raises with install hint",
+                   "gh" in msg and ("cli" in msg or "install" in msg),
+                   f"got: {e}")
+        except NotImplementedError as e:
+            # Expected during RED phase before Task 7
+            r.test("gh missing raises with install hint", False,
+                   f"RED: got NotImplementedError: {e}")
+        finally:
+            os.environ["PATH"] = old_path
+
+
+def test_pr_gh_succeeds(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        fake_diff = "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -0,0 +1 @@\n+hello\n"
+        fake_bin = _install_fake_gh(tmp, fake_diff, 0)
+        os.chdir(tmp)
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{fake_bin}:{old_path}"
+        try:
+            scope = prepare_diff_scope("1234", scope_file=Path(tmp) / "scope.txt", diff_file=Path(tmp) / "review.diff")
+            r.test("pr arg source correct", scope.source == "pr:1234",
+                   f"got {scope.source}")
+            r.test("pr arg parsed a.py from diff", "a.py" in scope.files,
+                   f"got {scope.files}")
+        except NotImplementedError as e:
+            r.test("pr arg source correct", False, f"RED: got NotImplementedError: {e}")
+            r.test("pr arg parsed a.py from diff", False, f"RED: got NotImplementedError: {e}")
+        finally:
+            os.environ["PATH"] = old_path
+
+
+def test_pr_gh_not_found(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        fake_bin = _install_fake_gh(tmp, "GraphQL: Could not resolve to a PullRequest", 1)
+        os.chdir(tmp)
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{fake_bin}:{old_path}"
+        try:
+            prepare_diff_scope("9999")
+            r.test("pr not-found raises", False, "no exception")
+        except DiffScopeError as e:
+            msg = str(e).lower()
+            r.test("pr not-found raises", "not found" in msg or "access" in msg,
+                   f"got: {e}")
+        except NotImplementedError as e:
+            r.test("pr not-found raises", False, f"RED: got NotImplementedError: {e}")
+        finally:
+            os.environ["PATH"] = old_path
+
+
+def test_pr_gh_not_authed(r: TestRunner):
+    with tempfile.TemporaryDirectory() as tmp:
+        make_repo(tmp)
+        fake_bin = _install_fake_gh(tmp, "auth status failed", 4)
+        os.chdir(tmp)
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{fake_bin}:{old_path}"
+        try:
+            prepare_diff_scope("1234")
+            r.test("pr not-authed raises", False, "no exception")
+        except DiffScopeError:
+            r.test("pr not-authed raises", True)
+        except NotImplementedError as e:
+            r.test("pr not-authed raises", False, f"RED: got NotImplementedError: {e}")
+        finally:
+            os.environ["PATH"] = old_path
+
+
 def main():
     runner = TestRunner()
     print("Empty-arg precedence:")
@@ -280,6 +386,12 @@ def main():
     test_range_arg_two_dot(runner)
     test_range_arg_three_dot(runner)
     test_range_arg_malformed(runner)
+
+    print("\nPR# arg:")
+    test_pr_gh_missing(runner)
+    test_pr_gh_succeeds(runner)
+    test_pr_gh_not_found(runner)
+    test_pr_gh_not_authed(runner)
     sys.exit(runner.summary())
 
 

--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "2.8.2",
+  "version": "3.0.0",
   "description": "Claude Code Requirements Framework - Complete development lifecycle from ideation to completion. Enforces workflow requirements through hooks, guides process with 19 development skills (brainstorming, TDD, debugging, verification), and provides comprehensive code review agents.",
   "author": {
     "name": "Harm"

--- a/plugins/requirements-framework/agents/adr-guardian.md
+++ b/plugins/requirements-framework/agents/adr-guardian.md
@@ -41,7 +41,7 @@ The adr-guardian agent acts as a gate before code writing begins to ensure ADR c
 </example>
 color: blue
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 You are the ADR Guardian, an authoritative architectural governance expert responsible for ensuring all code and plans comply with established Architecture Decision Records. You have BLOCKING authority - no code should be written or approved that violates ADRs.

--- a/plugins/requirements-framework/agents/adr-guardian.md
+++ b/plugins/requirements-framework/agents/adr-guardian.md
@@ -41,7 +41,7 @@ The adr-guardian agent acts as a gate before code writing begins to ensure ADR c
 </example>
 color: blue
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 You are the ADR Guardian, an authoritative architectural governance expert responsible for ensuring all code and plans comply with established Architecture Decision Records. You have BLOCKING authority - no code should be written or approved that violates ADRs.

--- a/plugins/requirements-framework/agents/appsec-auditor.md
+++ b/plugins/requirements-framework/agents/appsec-auditor.md
@@ -29,7 +29,7 @@ Auth code changes require careful security review for bypass vulnerabilities.
 </example>
 color: red
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 You are an expert application security auditor specializing in OWASP Top 10 vulnerabilities. Your mission is to find every exploitable security flaw in the code — injection, broken authentication, sensitive data exposure, security misconfiguration, and more.

--- a/plugins/requirements-framework/agents/appsec-auditor.md
+++ b/plugins/requirements-framework/agents/appsec-auditor.md
@@ -36,25 +36,15 @@ You are an expert application security auditor specializing in OWASP Top 10 vuln
 
 **Stack expertise**: .NET Core 9 (ASP.NET Core, EF Core), Angular (14+), Python (FastAPI, Flask), Azure (Key Vault, App Service, Functions).
 
-## Step 1: Get Code to Review
+## Step 1: Load Review Scope
 
-Execute these commands to identify changes:
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
 
-```bash
-git diff > /tmp/appsec_review.diff 2>&1
-if [ ! -s /tmp/appsec_review.diff ]; then
-  git diff --cached > /tmp/appsec_review.diff 2>&1
-fi
-```
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
 
-Then check the result:
-- If /tmp/appsec_review.diff is empty: Output "No changes to review" and EXIT
-- Otherwise: Read the diff and continue
-
-Extract from the diff:
-- Which files were modified
-- What specific changes were made
-- Input handling, auth, crypto, external calls
+Focus your review on the files in the scope; do not expand beyond them.
 
 ## Step 2: Gather Security Context
 

--- a/plugins/requirements-framework/agents/appsec-auditor.md
+++ b/plugins/requirements-framework/agents/appsec-auditor.md
@@ -29,7 +29,7 @@ Auth code changes require careful security review for bypass vulnerabilities.
 </example>
 color: red
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 You are an expert application security auditor specializing in OWASP Top 10 vulnerabilities. Your mission is to find every exploitable security flaw in the code — injection, broken authentication, sensitive data exposure, security misconfiguration, and more.

--- a/plugins/requirements-framework/agents/appsec-auditor.md
+++ b/plugins/requirements-framework/agents/appsec-auditor.md
@@ -44,7 +44,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Report findings only on scoped files, but read the full auth stack, input validation middleware, and session/token handling to judge security implications in context.
 
 ## Step 2: Gather Security Context
 

--- a/plugins/requirements-framework/agents/backward-compatibility-checker.md
+++ b/plugins/requirements-framework/agents/backward-compatibility-checker.md
@@ -49,7 +49,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Report findings only on scoped files, but you MUST read callers, consumers, and any serialized/persisted references to public APIs being changed. Compat cannot be assessed without knowing who depends on what.
 
 **Look for**:
 - Pydantic model field changes (`class ModelName(BaseModel):`)

--- a/plugins/requirements-framework/agents/backward-compatibility-checker.md
+++ b/plugins/requirements-framework/agents/backward-compatibility-checker.md
@@ -21,7 +21,7 @@ Use for database schema evolution analysis.
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 # Backward Compatibility Checker Agent

--- a/plugins/requirements-framework/agents/backward-compatibility-checker.md
+++ b/plugins/requirements-framework/agents/backward-compatibility-checker.md
@@ -41,12 +41,15 @@ You are a **backward compatibility specialist** that identifies breaking changes
 
 ## Workflow
 
-### Step 1: Analyze Git Diff for Schema Changes
+### Step 1: Load Review Scope
 
-```bash
-# Get full diff of staged changes
-git diff --cached
-```
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
+
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
+
+Focus your review on the files in the scope; do not expand beyond them.
 
 **Look for**:
 - Pydantic model field changes (`class ModelName(BaseModel):`)

--- a/plugins/requirements-framework/agents/backward-compatibility-checker.md
+++ b/plugins/requirements-framework/agents/backward-compatibility-checker.md
@@ -21,7 +21,7 @@ Use for database schema evolution analysis.
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 # Backward Compatibility Checker Agent

--- a/plugins/requirements-framework/agents/code-reviewer.md
+++ b/plugins/requirements-framework/agents/code-reviewer.md
@@ -35,25 +35,15 @@ git_hash: f6369fe
 
 You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.
 
-## Step 1: Get Code to Review
+## Step 1: Load Review Scope
 
-Execute these commands to identify changes:
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
 
-```bash
-git diff > /tmp/code_review.diff 2>&1
-if [ ! -s /tmp/code_review.diff ]; then
-  git diff --cached > /tmp/code_review.diff 2>&1
-fi
-```
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
 
-Then check the result:
-- If /tmp/code_review.diff is empty: Output "No changes to review" and EXIT
-- Otherwise: Read the diff and continue
-
-Extract from the diff:
-- Which files were modified
-- What specific changes were made
-- Language/framework used
+Focus your review on the files in the scope; do not expand beyond them.
 
 ## Step 2: Load Project Guidelines
 

--- a/plugins/requirements-framework/agents/code-reviewer.md
+++ b/plugins/requirements-framework/agents/code-reviewer.md
@@ -43,7 +43,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Report findings only on files in the scope. Read CLAUDE.md, project docs, imports, and callers of changed functions as needed to judge whether changes fit project conventions.
 
 ## Step 2: Load Project Guidelines
 

--- a/plugins/requirements-framework/agents/code-reviewer.md
+++ b/plugins/requirements-framework/agents/code-reviewer.md
@@ -30,7 +30,7 @@ Trigger on common pre-commit review phrases.
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.

--- a/plugins/requirements-framework/agents/code-reviewer.md
+++ b/plugins/requirements-framework/agents/code-reviewer.md
@@ -30,7 +30,7 @@ Trigger on common pre-commit review phrases.
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.

--- a/plugins/requirements-framework/agents/code-simplifier.md
+++ b/plugins/requirements-framework/agents/code-simplifier.md
@@ -20,7 +20,7 @@ assistant: "Now let me use the code-simplifier agent to refine this implementati
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. You prioritize readable, explicit code over overly compact solutions.

--- a/plugins/requirements-framework/agents/code-simplifier.md
+++ b/plugins/requirements-framework/agents/code-simplifier.md
@@ -33,7 +33,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Report findings only on scoped files. Read callers and usage sites before suggesting simplifications — what looks like dead complexity may exist for a use case elsewhere.
 
 ## Step 2: Load Project Standards
 

--- a/plugins/requirements-framework/agents/code-simplifier.md
+++ b/plugins/requirements-framework/agents/code-simplifier.md
@@ -20,7 +20,7 @@ assistant: "Now let me use the code-simplifier agent to refine this implementati
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. You prioritize readable, explicit code over overly compact solutions.

--- a/plugins/requirements-framework/agents/code-simplifier.md
+++ b/plugins/requirements-framework/agents/code-simplifier.md
@@ -25,20 +25,15 @@ git_hash: f6369fe
 
 You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. You prioritize readable, explicit code over overly compact solutions.
 
-## Step 1: Identify Code to Simplify
+## Step 1: Load Review Scope
 
-Execute these commands to find recently modified code:
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
 
-```bash
-git diff --cached --name-only --diff-filter=ACMR > /tmp/simplify_scope.txt 2>&1
-if [ ! -s /tmp/simplify_scope.txt ]; then
-  git diff --name-only --diff-filter=ACMR > /tmp/simplify_scope.txt 2>&1
-fi
-```
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
 
-If empty: Output "No changes to simplify" and EXIT
-
-Otherwise: Read the files and the diff to understand what changed
+Focus your review on the files in the scope; do not expand beyond them.
 
 ## Step 2: Load Project Standards
 

--- a/plugins/requirements-framework/agents/codex-arch-reviewer.md
+++ b/plugins/requirements-framework/agents/codex-arch-reviewer.md
@@ -22,7 +22,7 @@ description: |
   </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 # Codex Architecture Review Agent

--- a/plugins/requirements-framework/agents/codex-arch-reviewer.md
+++ b/plugins/requirements-framework/agents/codex-arch-reviewer.md
@@ -22,7 +22,7 @@ description: |
   </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 # Codex Architecture Review Agent

--- a/plugins/requirements-framework/agents/codex-review-agent.md
+++ b/plugins/requirements-framework/agents/codex-review-agent.md
@@ -21,7 +21,7 @@ Codex provides a different perspective from Claude's review.
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 # Codex Code Review Agent

--- a/plugins/requirements-framework/agents/codex-review-agent.md
+++ b/plugins/requirements-framework/agents/codex-review-agent.md
@@ -78,48 +78,49 @@ This will open your browser for authentication.
   /requirements-framework:codex-review
 ```
 
-### 2. Determine Review Scope
+### 2. Load Review Scope
 
-**Check for changes**:
-```bash
-git status --porcelain
-```
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
 
-**Detect current branch**:
-```bash
-git branch --show-current
-```
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
 
-**Decision Logic**:
-- If uncommitted changes exist → Review uncommitted changes
-- If on feature branch with no uncommitted changes → Review branch vs main
-- If no changes at all → Show friendly "no changes" message
+Focus your review on the files in the scope; do not expand beyond them.
 
 ### 3. Execute Codex Review
 
 **Parse focus area** from $ARGUMENTS (if provided): security, performance, bugs, style, or all (default)
 
-**Command Options**:
+Feed the pre-computed diff at `/tmp/review.diff` to Codex via `codex exec`
+so every reviewer sees the same unified scope:
 
-**Option A** - Uncommitted changes (default when changes exist):
+**Option A** - Review the pre-computed scope diff (default):
 ```bash
-codex review --uncommitted
+codex exec --stdin <<EOF
+Review the following unified diff for code quality issues. Report findings
+with severity (CRITICAL / IMPORTANT / SUGGESTION), file:line locations, and
+concrete fix suggestions.
+
+$(cat /tmp/review.diff)
+EOF
 ```
 
-**Option B** - With focus area:
+**Option B** - Review with a focus area:
 ```bash
-codex review --uncommitted --focus security
+FOCUS="security"  # or performance, bugs, style
+codex exec --stdin <<EOF
+Review the following unified diff with a focus on ${FOCUS}. Report findings
+with severity (CRITICAL / IMPORTANT / SUGGESTION), file:line locations, and
+concrete fix suggestions.
+
+$(cat /tmp/review.diff)
+EOF
 ```
 
-**Option C** - Full branch review (when no uncommitted changes):
-```bash
-codex review --base main
-```
-
-**Option D** - Branch with focus:
-```bash
-codex review --base main --focus performance
-```
+If `codex exec` is not available in the installed Codex CLI version, fall
+back to `codex review --uncommitted` (or `codex review --base main` when no
+uncommitted changes exist) and note the fallback in the output.
 
 ### 4. Parse and Present Results
 

--- a/plugins/requirements-framework/agents/codex-review-agent.md
+++ b/plugins/requirements-framework/agents/codex-review-agent.md
@@ -86,7 +86,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Codex receives the unified diff and forms its own context. Your job is to invoke codex and format its output — do not add manual scope restriction to the codex prompt.
 
 ### 3. Execute Codex Review
 

--- a/plugins/requirements-framework/agents/codex-review-agent.md
+++ b/plugins/requirements-framework/agents/codex-review-agent.md
@@ -21,7 +21,7 @@ Codex provides a different perspective from Claude's review.
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 # Codex Code Review Agent

--- a/plugins/requirements-framework/agents/comment-analyzer.md
+++ b/plugins/requirements-framework/agents/comment-analyzer.md
@@ -38,7 +38,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Focus findings on comments in scoped files. Read surrounding code to judge whether a comment is redundant, misleading, or accurately documents non-obvious intent.
 
 ## Step 2: Identify Comments in Changed Code
 

--- a/plugins/requirements-framework/agents/comment-analyzer.md
+++ b/plugins/requirements-framework/agents/comment-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the comment-analyzer agent to review the documentation."
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 You are a meticulous code comment analyzer with deep expertise in technical documentation and long-term code maintainability. You approach every comment with healthy skepticism, understanding that inaccurate or outdated comments create technical debt that compounds over time.

--- a/plugins/requirements-framework/agents/comment-analyzer.md
+++ b/plugins/requirements-framework/agents/comment-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the comment-analyzer agent to review the documentation."
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 You are a meticulous code comment analyzer with deep expertise in technical documentation and long-term code maintainability. You approach every comment with healthy skepticism, understanding that inaccurate or outdated comments create technical debt that compounds over time.

--- a/plugins/requirements-framework/agents/comment-analyzer.md
+++ b/plugins/requirements-framework/agents/comment-analyzer.md
@@ -30,18 +30,15 @@ Your primary mission is to protect codebases from comment rot by ensuring every 
 
 IMPORTANT: You analyze and provide feedback only. Do not modify code or comments directly. Your role is advisory.
 
-## Step 1: Get Changes to Analyze
+## Step 1: Load Review Scope
 
-Execute these commands to identify changed files:
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
 
-```bash
-git diff --cached --name-only --diff-filter=ACMR > /tmp/comment_scope.txt 2>&1
-if [ ! -s /tmp/comment_scope.txt ]; then
-  git diff --name-only --diff-filter=ACMR > /tmp/comment_scope.txt 2>&1
-fi
-```
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
 
-If empty: Output "No changes to analyze" and EXIT
+Focus your review on the files in the scope; do not expand beyond them.
 
 ## Step 2: Identify Comments in Changed Code
 

--- a/plugins/requirements-framework/agents/comment-cleaner.md
+++ b/plugins/requirements-framework/agents/comment-cleaner.md
@@ -21,7 +21,7 @@ Comment-cleaner auto-fixes by editing files directly.
 </example>
 model: haiku
 color: yellow
-git_hash: 5b1c418
+git_hash: 068e1d5
 allowed-tools: ["Read", "Edit", "Glob", "Grep", "Bash"]
 ---
 

--- a/plugins/requirements-framework/agents/comment-cleaner.md
+++ b/plugins/requirements-framework/agents/comment-cleaner.md
@@ -21,7 +21,7 @@ Comment-cleaner auto-fixes by editing files directly.
 </example>
 model: haiku
 color: yellow
-git_hash: f6369fe
+git_hash: 5b1c418
 allowed-tools: ["Read", "Edit", "Glob", "Grep", "Bash"]
 ---
 

--- a/plugins/requirements-framework/agents/commit-planner.md
+++ b/plugins/requirements-framework/agents/commit-planner.md
@@ -24,7 +24,7 @@ Commit planning before implementation helps maintain clean git history and enabl
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 You are the Commit Planner, an expert at analyzing implementation plans and creating atomic commit strategies. Your role is to ensure code changes are committed in logical, reviewable chunks that follow proper dependency ordering.

--- a/plugins/requirements-framework/agents/commit-planner.md
+++ b/plugins/requirements-framework/agents/commit-planner.md
@@ -24,7 +24,7 @@ Commit planning before implementation helps maintain clean git history and enabl
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 You are the Commit Planner, an expert at analyzing implementation plans and creating atomic commit strategies. Your role is to ensure code changes are committed in logical, reviewable chunks that follow proper dependency ordering.

--- a/plugins/requirements-framework/agents/compliance-auditor.md
+++ b/plugins/requirements-framework/agents/compliance-auditor.md
@@ -38,25 +38,15 @@ You are an expert regulatory compliance auditor specializing in GDPR/AVG (Dutch 
 
 **Regulatory expertise**: GDPR (EU 2016/679), AVG (Algemene Verordening Gegevensbescherming — Dutch GDPR implementation), Telecommunicatiewet, NOvA Verordening op de advocatuur, Wet ter voorkoming van witwassen en financieren van terrorisme (Wwft), Advocatenwet.
 
-## Step 1: Get Code to Review
+## Step 1: Load Review Scope
 
-Execute these commands to identify changes:
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
 
-```bash
-git diff > /tmp/compliance_review.diff 2>&1
-if [ ! -s /tmp/compliance_review.diff ]; then
-  git diff --cached > /tmp/compliance_review.diff 2>&1
-fi
-```
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
 
-Then check the result:
-- If /tmp/compliance_review.diff is empty: Output "No changes to review" and EXIT
-- Otherwise: Read the diff and continue
-
-Extract from the diff:
-- Which files were modified
-- What specific changes were made
-- Data handling, logging, access control, audit patterns
+Focus your review on the files in the scope; do not expand beyond them.
 
 ## Step 2: Gather Compliance Context
 

--- a/plugins/requirements-framework/agents/compliance-auditor.md
+++ b/plugins/requirements-framework/agents/compliance-auditor.md
@@ -29,7 +29,7 @@ Cross-organization sharing in legal platforms requires verschoningsrecht classif
 </example>
 color: red
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 You are an expert regulatory compliance auditor specializing in GDPR/AVG (Dutch implementation), legal professional privilege, and Netherlands Bar Association (NOvA) requirements. Your mission is to find every compliance gap in code that handles personal data, audit trails, privileged communications, and regulated financial flows in Dutch law firm software.

--- a/plugins/requirements-framework/agents/compliance-auditor.md
+++ b/plugins/requirements-framework/agents/compliance-auditor.md
@@ -29,7 +29,7 @@ Cross-organization sharing in legal platforms requires verschoningsrecht classif
 </example>
 color: red
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 You are an expert regulatory compliance auditor specializing in GDPR/AVG (Dutch implementation), legal professional privilege, and Netherlands Bar Association (NOvA) requirements. Your mission is to find every compliance gap in code that handles personal data, audit trails, privileged communications, and regulated financial flows in Dutch law firm software.

--- a/plugins/requirements-framework/agents/compliance-auditor.md
+++ b/plugins/requirements-framework/agents/compliance-auditor.md
@@ -46,7 +46,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Report findings only on scoped files, but read data-flow patterns (PII storage, audit logging, retention policies, consent flags) to judge compliance across the system.
 
 ## Step 2: Gather Compliance Context
 

--- a/plugins/requirements-framework/agents/frontend-reviewer.md
+++ b/plugins/requirements-framework/agents/frontend-reviewer.md
@@ -35,39 +35,30 @@ git_hash: f6369fe
 
 You are an expert React frontend reviewer specializing in modern React patterns, accessibility (WCAG), performance optimization, and component architecture. Your primary responsibility is to review frontend code against React best practices and project-specific checklists with high precision to minimize false positives.
 
-## Step 1: Get Changes and Scope to Frontend Files
+## Step 1: Load Review Scope
 
-Execute these commands to identify frontend changes:
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
+
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
+
+Focus your review on the files in the scope; do not expand beyond them.
+
+Narrow to frontend files within the scope:
 
 ```bash
-git diff --cached --name-only --diff-filter=ACMR > /tmp/frontend_review_all.txt 2>&1
-if [ ! -s /tmp/frontend_review_all.txt ]; then
-  git diff --name-only --diff-filter=ACMR > /tmp/frontend_review_all.txt 2>&1
-fi
+grep -E '\.(tsx|jsx|css|scss|sass|less|module\.css|module\.scss)$' /tmp/review_scope.txt > /tmp/frontend_review_scope.txt 2>&1 || true
 
-# Filter to frontend files
-grep -E '\.(tsx|jsx|css|scss|sass|less|module\.css|module\.scss)$' /tmp/frontend_review_all.txt > /tmp/frontend_review_scope.txt 2>&1 || true
-
-# Also check .ts files for React imports
-for f in $(grep '\.ts$' /tmp/frontend_review_all.txt 2>/dev/null); do
+# Also include .ts files with React-related imports
+for f in $(grep '\.ts$' /tmp/review_scope.txt 2>/dev/null); do
   if git show :"$f" 2>/dev/null | grep -qE 'from .react|from .@emotion|from .styled-components|from .next'; then
     echo "$f" >> /tmp/frontend_review_scope.txt
   fi
 done 2>/dev/null || true
 ```
 
-Then check the result:
-- If /tmp/frontend_review_scope.txt is empty or does not exist: Output "No frontend changes to review" and **EXIT**
-- Otherwise: Read the file list, then read the full diff for those files:
-
-```bash
-git diff --cached -- $(cat /tmp/frontend_review_scope.txt | tr '\n' ' ') > /tmp/frontend_review.diff 2>&1
-if [ ! -s /tmp/frontend_review.diff ]; then
-  git diff -- $(cat /tmp/frontend_review_scope.txt | tr '\n' ' ') > /tmp/frontend_review.diff 2>&1
-fi
-```
-
-Read the diff and continue.
+If `/tmp/frontend_review_scope.txt` is empty: Output "No frontend changes to review" and EXIT.
 
 ## Step 2: Load Project Guidelines and Checklist
 

--- a/plugins/requirements-framework/agents/frontend-reviewer.md
+++ b/plugins/requirements-framework/agents/frontend-reviewer.md
@@ -30,7 +30,7 @@ description: |
   </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 You are an expert React frontend reviewer specializing in modern React patterns, accessibility (WCAG), performance optimization, and component architecture. Your primary responsibility is to review frontend code against React best practices and project-specific checklists with high precision to minimize false positives.

--- a/plugins/requirements-framework/agents/frontend-reviewer.md
+++ b/plugins/requirements-framework/agents/frontend-reviewer.md
@@ -30,7 +30,7 @@ description: |
   </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 You are an expert React frontend reviewer specializing in modern React patterns, accessibility (WCAG), performance optimization, and component architecture. Your primary responsibility is to review frontend code against React best practices and project-specific checklists with high precision to minimize false positives.

--- a/plugins/requirements-framework/agents/frontend-reviewer.md
+++ b/plugins/requirements-framework/agents/frontend-reviewer.md
@@ -43,7 +43,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Report findings only on scoped files. Read the component hierarchy, shared hooks, context providers, and style system to judge React, accessibility, and performance issues in context.
 
 Narrow to frontend files within the scope:
 

--- a/plugins/requirements-framework/agents/import-organizer.md
+++ b/plugins/requirements-framework/agents/import-organizer.md
@@ -21,7 +21,7 @@ Import-organizer auto-fixes by editing files directly.
 </example>
 model: haiku
 color: yellow
-git_hash: 5b1c418
+git_hash: 068e1d5
 allowed-tools: ["Read", "Edit", "Glob", "Grep", "Bash"]
 ---
 

--- a/plugins/requirements-framework/agents/import-organizer.md
+++ b/plugins/requirements-framework/agents/import-organizer.md
@@ -21,7 +21,7 @@ Import-organizer auto-fixes by editing files directly.
 </example>
 model: haiku
 color: yellow
-git_hash: f6369fe
+git_hash: 5b1c418
 allowed-tools: ["Read", "Edit", "Glob", "Grep", "Bash"]
 ---
 

--- a/plugins/requirements-framework/agents/refactor-advisor.md
+++ b/plugins/requirements-framework/agents/refactor-advisor.md
@@ -34,7 +34,7 @@ description: |
 
 color: yellow
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 You are the Refactor Advisor, responsible for analyzing a planned change and the existing codebase to identify **preparatory refactoring** — structural improvements to existing code that should be done *before* the main change to make it easier, simpler, and less risky.

--- a/plugins/requirements-framework/agents/refactor-advisor.md
+++ b/plugins/requirements-framework/agents/refactor-advisor.md
@@ -34,7 +34,7 @@ description: |
 
 color: yellow
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 You are the Refactor Advisor, responsible for analyzing a planned change and the existing codebase to identify **preparatory refactoring** — structural improvements to existing code that should be done *before* the main change to make it easier, simpler, and less risky.

--- a/plugins/requirements-framework/agents/session-analyzer.md
+++ b/plugins/requirements-framework/agents/session-analyzer.md
@@ -21,7 +21,7 @@ The session-reflect command automatically invokes this agent.
 </example>
 color: magenta
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 You are a session learning analyst. Your role is to analyze session metrics and identify patterns that can improve future Claude Code sessions.

--- a/plugins/requirements-framework/agents/session-analyzer.md
+++ b/plugins/requirements-framework/agents/session-analyzer.md
@@ -21,7 +21,7 @@ The session-reflect command automatically invokes this agent.
 </example>
 color: magenta
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 You are a session learning analyst. Your role is to analyze session metrics and identify patterns that can improve future Claude Code sessions.

--- a/plugins/requirements-framework/agents/silent-failure-hunter.md
+++ b/plugins/requirements-framework/agents/silent-failure-hunter.md
@@ -21,7 +21,7 @@ assistant: "Let me use the silent-failure-hunter agent to ensure no silent failu
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 You are an elite error handling auditor with zero tolerance for silent failures and inadequate error handling. Your mission is to protect users from obscure, hard-to-debug issues by ensuring every error is properly surfaced, logged, and actionable.

--- a/plugins/requirements-framework/agents/silent-failure-hunter.md
+++ b/plugins/requirements-framework/agents/silent-failure-hunter.md
@@ -21,7 +21,7 @@ assistant: "Let me use the silent-failure-hunter agent to ensure no silent failu
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 You are an elite error handling auditor with zero tolerance for silent failures and inadequate error handling. Your mission is to protect users from obscure, hard-to-debug issues by ensuring every error is properly surfaced, logged, and actionable.

--- a/plugins/requirements-framework/agents/silent-failure-hunter.md
+++ b/plugins/requirements-framework/agents/silent-failure-hunter.md
@@ -159,16 +159,13 @@ First, check if CLAUDE.md or project documentation defines specific error handli
 
 ## Step 2: Identify Code to Audit
 
-Execute these commands to get error-handling-relevant changes:
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
 
-```bash
-git diff > /tmp/error_audit.diff 2>&1
-if [ ! -s /tmp/error_audit.diff ]; then
-  git diff --cached > /tmp/error_audit.diff 2>&1
-fi
-```
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
 
-If empty: Output "No changes to audit" and EXIT
+Focus your review on the files in the scope; do not expand beyond them.
 
 Focus on:
 - try/catch/except blocks (new or modified)

--- a/plugins/requirements-framework/agents/silent-failure-hunter.md
+++ b/plugins/requirements-framework/agents/silent-failure-hunter.md
@@ -165,7 +165,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Report findings only on scoped files. Read related error-handling code, exception classes, logging setup, and retry/fallback infrastructure to judge whether new error paths are consistent with the rest of the codebase.
 
 Focus on:
 - try/catch/except blocks (new or modified)

--- a/plugins/requirements-framework/agents/solid-reviewer.md
+++ b/plugins/requirements-framework/agents/solid-reviewer.md
@@ -24,7 +24,7 @@ SOLID validation is a blocking gate in the plan-review workflow.
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 You are the SOLID Principles Reviewer, responsible for ensuring implementation plans adhere to SOLID design principles before coding begins. You have BLOCKING authority — plans with egregious SOLID violations should not proceed to implementation.

--- a/plugins/requirements-framework/agents/solid-reviewer.md
+++ b/plugins/requirements-framework/agents/solid-reviewer.md
@@ -24,7 +24,7 @@ SOLID validation is a blocking gate in the plan-review workflow.
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 You are the SOLID Principles Reviewer, responsible for ensuring implementation plans adhere to SOLID design principles before coding begins. You have BLOCKING authority — plans with egregious SOLID violations should not proceed to implementation.

--- a/plugins/requirements-framework/agents/tdd-validator.md
+++ b/plugins/requirements-framework/agents/tdd-validator.md
@@ -24,7 +24,7 @@ TDD validation is a blocking gate in the plan-review workflow.
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 You are the TDD Validator, responsible for ensuring all implementation plans include proper Test-Driven Development elements before coding begins. You have BLOCKING authority - plans should not proceed to implementation without TDD readiness.

--- a/plugins/requirements-framework/agents/tdd-validator.md
+++ b/plugins/requirements-framework/agents/tdd-validator.md
@@ -24,7 +24,7 @@ TDD validation is a blocking gate in the plan-review workflow.
 
 color: green
 allowed-tools: ["Read", "Edit", "Glob", "Grep"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 You are the TDD Validator, responsible for ensuring all implementation plans include proper Test-Driven Development elements before coding begins. You have BLOCKING authority - plans should not proceed to implementation without TDD readiness.

--- a/plugins/requirements-framework/agents/tenant-isolation-auditor.md
+++ b/plugins/requirements-framework/agents/tenant-isolation-auditor.md
@@ -44,7 +44,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Report findings only on scoped files, but you MUST read tenant-boundary infrastructure (row-level security, tenant context providers, auth middleware, query filters) to judge whether new code honors or breaks isolation.
 
 ## Step 2: Gather Tenant Isolation Context
 

--- a/plugins/requirements-framework/agents/tenant-isolation-auditor.md
+++ b/plugins/requirements-framework/agents/tenant-isolation-auditor.md
@@ -29,7 +29,7 @@ Background jobs are high-risk for tenant isolation — they often run outside re
 </example>
 color: red
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 You are an expert multi-tenant security auditor specializing in tenant isolation for SaaS platforms. Your mission is to find every path where data from one tenant could leak to another — whether through missing query filters, shared caches, background jobs, or infrastructure misconfiguration.

--- a/plugins/requirements-framework/agents/tenant-isolation-auditor.md
+++ b/plugins/requirements-framework/agents/tenant-isolation-auditor.md
@@ -36,25 +36,15 @@ You are an expert multi-tenant security auditor specializing in tenant isolation
 
 **Stack expertise**: .NET Core 9, Entity Framework Core, Angular, Azure (Blob Storage, Table Storage, Functions, Service Bus), Python microservices.
 
-## Step 1: Get Code to Review
+## Step 1: Load Review Scope
 
-Execute these commands to identify changes:
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
 
-```bash
-git diff > /tmp/tenant_isolation_review.diff 2>&1
-if [ ! -s /tmp/tenant_isolation_review.diff ]; then
-  git diff --cached > /tmp/tenant_isolation_review.diff 2>&1
-fi
-```
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
 
-Then check the result:
-- If /tmp/tenant_isolation_review.diff is empty: Output "No changes to review" and EXIT
-- Otherwise: Read the diff and continue
-
-Extract from the diff:
-- Which files were modified
-- What specific changes were made
-- Data access patterns, caching, background jobs, Azure resources
+Focus your review on the files in the scope; do not expand beyond them.
 
 ## Step 2: Gather Tenant Isolation Context
 

--- a/plugins/requirements-framework/agents/tenant-isolation-auditor.md
+++ b/plugins/requirements-framework/agents/tenant-isolation-auditor.md
@@ -29,7 +29,7 @@ Background jobs are high-risk for tenant isolation — they often run outside re
 </example>
 color: red
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 You are an expert multi-tenant security auditor specializing in tenant isolation for SaaS platforms. Your mission is to find every path where data from one tenant could leak to another — whether through missing query filters, shared caches, background jobs, or infrastructure misconfiguration.

--- a/plugins/requirements-framework/agents/test-analyzer.md
+++ b/plugins/requirements-framework/agents/test-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the test-analyzer agent to review test coverage quality."
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 You are an expert test coverage analyst specializing in code review. Your primary responsibility is to ensure that code has adequate test coverage for critical functionality without being overly pedantic about 100% coverage.

--- a/plugins/requirements-framework/agents/test-analyzer.md
+++ b/plugins/requirements-framework/agents/test-analyzer.md
@@ -34,7 +34,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Report findings only on scoped files. Read related implementation files, `conftest.py`, shared fixtures, and existing test patterns to judge whether test changes cover behavior and follow project conventions.
 
 Partition the scope into source vs test files:
 

--- a/plugins/requirements-framework/agents/test-analyzer.md
+++ b/plugins/requirements-framework/agents/test-analyzer.md
@@ -26,22 +26,22 @@ git_hash: f6369fe
 
 You are an expert test coverage analyst specializing in code review. Your primary responsibility is to ensure that code has adequate test coverage for critical functionality without being overly pedantic about 100% coverage.
 
-## Step 1: Get Changes to Analyze
+## Step 1: Load Review Scope
 
-Execute these commands to identify code and test changes:
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
+
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
+
+Focus your review on the files in the scope; do not expand beyond them.
+
+Partition the scope into source vs test files:
 
 ```bash
-git diff --cached --name-only --diff-filter=ACMR > /tmp/all_changes.txt 2>&1
-if [ ! -s /tmp/all_changes.txt ]; then
-  git diff --name-only --diff-filter=ACMR > /tmp/all_changes.txt 2>&1
-fi
-
-# Separate source files from test files
-grep -vE '(test_|_test\.|\.test\.|\.spec\.)' /tmp/all_changes.txt > /tmp/source_changes.txt 2>&1 || true
-grep -E '(test_|_test\.|\.test\.|\.spec\.)' /tmp/all_changes.txt > /tmp/test_changes.txt 2>&1 || true
+grep -vE '(test_|_test\.|\.test\.|\.spec\.)' /tmp/review_scope.txt > /tmp/source_changes.txt 2>&1 || true
+grep -E '(test_|_test\.|\.test\.|\.spec\.)' /tmp/review_scope.txt > /tmp/test_changes.txt 2>&1 || true
 ```
-
-If both files are empty: Output "No changes to analyze" and EXIT
 
 ## Step 2: Check for Missing Test Coverage - CRITICAL GAP DETECTION
 

--- a/plugins/requirements-framework/agents/test-analyzer.md
+++ b/plugins/requirements-framework/agents/test-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the test-analyzer agent to review test coverage quality."
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 You are an expert test coverage analyst specializing in code review. Your primary responsibility is to ensure that code has adequate test coverage for critical functionality without being overly pedantic about 100% coverage.

--- a/plugins/requirements-framework/agents/tool-validator.md
+++ b/plugins/requirements-framework/agents/tool-validator.md
@@ -21,7 +21,7 @@ Tool-validator provides deterministic results matching CI tools.
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 # Tool Validator Agent

--- a/plugins/requirements-framework/agents/tool-validator.md
+++ b/plugins/requirements-framework/agents/tool-validator.md
@@ -20,6 +20,7 @@ Tool-validator provides deterministic results matching CI tools.
 </commentary>
 </example>
 color: blue
+allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
 git_hash: f6369fe
 ---
 
@@ -40,14 +41,17 @@ You are a **tool execution specialist** that runs the actual linting and type-ch
 
 ## Workflow
 
-### Step 1: Identify Staged Files
+### Step 1: Load Review Scope
 
-```bash
-# Get all staged files
-git diff --cached --name-only --diff-filter=ACMR
-```
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
 
-Group by file type:
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
+
+Focus your review on the files in the scope; do not expand beyond them.
+
+Group the scope by file type for downstream tool selection:
 - Python: `*.py`
 - TypeScript: `*.ts`, `*.tsx`
 - JSON/YAML: `*.json`, `*.yaml` (for syntax validation)

--- a/plugins/requirements-framework/agents/tool-validator.md
+++ b/plugins/requirements-framework/agents/tool-validator.md
@@ -49,7 +49,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Findings must reference scoped files. The tools you invoke (pyright, ruff, eslint, etc.) naturally read project config and imports — that's expected.
 
 Group the scope by file type for downstream tool selection:
 - Python: `*.py`

--- a/plugins/requirements-framework/agents/tool-validator.md
+++ b/plugins/requirements-framework/agents/tool-validator.md
@@ -21,7 +21,7 @@ Tool-validator provides deterministic results matching CI tools.
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 # Tool Validator Agent

--- a/plugins/requirements-framework/agents/type-design-analyzer.md
+++ b/plugins/requirements-framework/agents/type-design-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the type-design-analyzer agent to evaluate the type invaria
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: f6369fe
+git_hash: ae56c58
 ---
 
 You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.

--- a/plugins/requirements-framework/agents/type-design-analyzer.md
+++ b/plugins/requirements-framework/agents/type-design-analyzer.md
@@ -26,18 +26,15 @@ git_hash: f6369fe
 
 You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.
 
-## Step 1: Get Changes and Identify Types to Review
+## Step 1: Load Review Scope
 
-Execute these commands:
+Execute: `${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope --ensure`
 
-```bash
-git diff --cached > /tmp/type_review.diff 2>&1
-if [ ! -s /tmp/type_review.diff ]; then
-  git diff > /tmp/type_review.diff 2>&1
-fi
-```
+Read `/tmp/review_scope.txt` (list of changed files, one per line) and
+`/tmp/review.diff` (unified diff). If the scope file is empty, output
+"No review scope provided" and EXIT.
 
-If empty: Output "No changes to review" and EXIT
+Focus your review on the files in the scope; do not expand beyond them.
 
 ## Step 2: Identify Type Definitions in Changes
 

--- a/plugins/requirements-framework/agents/type-design-analyzer.md
+++ b/plugins/requirements-framework/agents/type-design-analyzer.md
@@ -21,7 +21,7 @@ assistant: "I'll use the type-design-analyzer agent to evaluate the type invaria
 </example>
 color: blue
 allowed-tools: ["Bash", "Read", "Glob", "Grep", "SendMessage", "TaskUpdate"]
-git_hash: ae56c58
+git_hash: 2aac66f
 ---
 
 You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.

--- a/plugins/requirements-framework/agents/type-design-analyzer.md
+++ b/plugins/requirements-framework/agents/type-design-analyzer.md
@@ -34,7 +34,7 @@ Read `/tmp/review_scope.txt` (list of changed files, one per line) and
 `/tmp/review.diff` (unified diff). If the scope file is empty, output
 "No review scope provided" and EXIT.
 
-Focus your review on the files in the scope; do not expand beyond them.
+Report findings only on scoped files. Follow type references into other modules, base classes, and protocols to judge whether new types compose correctly and don't weaken downstream invariants.
 
 ## Step 2: Identify Type Definitions in Changes
 

--- a/plugins/requirements-framework/commands/arch-review.md
+++ b/plugins/requirements-framework/commands/arch-review.md
@@ -3,7 +3,7 @@ name: arch-review
 description: "Multi-perspective team-based architecture review with agent debate and commit planning"
 argument-hint: "[plan-file-path]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: ea8efe0
+git_hash: 068e1d5
 ---
 
 # Architecture Review — Team-Based Multi-Perspective Assessment

--- a/plugins/requirements-framework/commands/arch-review.md
+++ b/plugins/requirements-framework/commands/arch-review.md
@@ -17,32 +17,33 @@ Satisfies all 4 planning requirements: `commit_plan`, `adr_reviewed`, `tdd_plann
 
 You MUST follow these steps in exact order. Do not skip steps or interpret - execute as written.
 
-### Step 1: Locate Plan File
+## Step 0: Resolve Plan File
 
-Check `$ARGUMENTS` for an explicit path first, then auto-discover:
+If `$ARGUMENTS` is provided, treat it as the plan file path:
 
 ```bash
-# Check for explicit argument
-if [ -n "$ARGUMENTS" ]; then
+if [[ -n "$ARGUMENTS" ]]; then
   PLAN_FILE="$ARGUMENTS"
+else
+  # Search conventional plan directories, most-recently-modified first.
+  PLAN_FILE="$(ls -t docs/plans/*.md .claude/plans/*.md ~/.claude/plans/*.md 2>/dev/null | head -1)"
 fi
 
-# Auto-discover if no argument
-if [ -z "$PLAN_FILE" ] || [ ! -f "$PLAN_FILE" ]; then
-  PLAN_FILE=$(ls -t .claude/plans/*.md 2>/dev/null | head -1)
+if [[ -z "$PLAN_FILE" ]] || [[ ! -f "$PLAN_FILE" ]]; then
+  echo "No plan file found. Pass a path or create one under docs/plans/, .claude/plans/, or ~/.claude/plans/." >&2
+  exit 2
 fi
-if [ -z "$PLAN_FILE" ] || [ ! -f "$PLAN_FILE" ]; then
-  PLAN_FILE=$(ls -t ~/.claude/plans/*.md 2>/dev/null | head -1)
-fi
+
+echo "Reviewing plan: $PLAN_FILE"
 ```
 
-If no plan file found:
-- Output: "No plan file found. Create a plan in plan mode first, then run this command."
-- **EXIT**
+Pass `$PLAN_FILE` to every teammate / subagent prompt — they should read the plan from that exact path.
 
-Output: "Found plan file: [PLAN_FILE]"
+### Step 1: Locate Plan File
 
-Read the plan file content for use in teammate prompts.
+`$PLAN_FILE` is already resolved by Step 0. Read its content for use in teammate prompts.
+
+Output: "Found plan file: $PLAN_FILE"
 
 ### Step 2: Locate Project ADRs
 
@@ -95,44 +96,44 @@ For each review task (NOT the synthesis task), spawn a teammate:
 **adr-guardian teammate**:
 - `subagent_type`: "requirements-framework:adr-guardian"
 - `name`: "adr-guardian"
-- `prompt`: Include plan file content, ADR directory listing, and instruction:
-  "Review this plan against all project ADRs. Check for violations, missing ADRs, and compliance gaps. Share findings via SendMessage with severity levels. Mark task complete when done."
+- `prompt`: Pass the plan file path `$PLAN_FILE`, ADR directory listing, and instruction:
+  "Read the plan from `$PLAN_FILE`. Review this plan against all project ADRs. Check for violations, missing ADRs, and compliance gaps. Share findings via SendMessage with severity levels. Mark task complete when done."
 
 **backward-compatibility-checker teammate**:
 - `subagent_type`: "requirements-framework:backward-compatibility-checker"
 - `name`: "compat-checker"
-- `prompt`: Include plan file content and instruction:
-  "Analyze this plan for breaking changes: renamed fields, removed APIs, changed schemas, migration needs. Share findings via SendMessage with severity levels. Mark task complete when done."
+- `prompt`: Pass the plan file path `$PLAN_FILE` and instruction:
+  "Read the plan from `$PLAN_FILE`. Analyze this plan for breaking changes: renamed fields, removed APIs, changed schemas, migration needs. Share findings via SendMessage with severity levels. Mark task complete when done."
 
 **tdd-validator teammate**:
 - `subagent_type`: "requirements-framework:tdd-validator"
 - `name`: "tdd-validator"
-- `prompt`: Include plan file content and instruction:
-  "Assess the testability of this plan: Does it include test strategy? Are breaking changes covered by tests? Does the TDD sequence account for all components? Share findings via SendMessage. Mark task complete when done."
+- `prompt`: Pass the plan file path `$PLAN_FILE` and instruction:
+  "Read the plan from `$PLAN_FILE`. Assess the testability of this plan: Does it include test strategy? Are breaking changes covered by tests? Does the TDD sequence account for all components? Share findings via SendMessage. Mark task complete when done."
 
 **solid-reviewer teammate**:
 - `subagent_type`: "requirements-framework:solid-reviewer"
 - `name`: "solid-reviewer"
-- `prompt`: Include plan file content and instruction:
-  "Assess this plan for SOLID principles violations with Python focus. Scale strictness to plan size (1-2 files: SRP only, 3-5: SRP+DIP, 6+: full SOLID). Share findings via SendMessage with severity levels. Mark task complete when done."
+- `prompt`: Pass the plan file path `$PLAN_FILE` and instruction:
+  "Read the plan from `$PLAN_FILE`. Assess this plan for SOLID principles violations with Python focus. Scale strictness to plan size (1-2 files: SRP only, 3-5: SRP+DIP, 6+: full SOLID). Share findings via SendMessage with severity levels. Mark task complete when done."
 
 **refactor-advisor teammate**:
 - `subagent_type`: "requirements-framework:refactor-advisor"
 - `name`: "refactor-advisor"
-- `prompt`: Include plan file content and instruction:
-  "Analyze this plan and the existing codebase to identify preparatory refactoring opportunities — structural improvements to existing code that would make the planned change easier to implement. Add a '## Preparatory Refactoring' section to the plan file using the Edit tool. Share findings via SendMessage with severity levels. Mark task complete when done."
+- `prompt`: Pass the plan file path `$PLAN_FILE` and instruction:
+  "Read the plan from `$PLAN_FILE`. Analyze this plan and the existing codebase to identify preparatory refactoring opportunities — structural improvements to existing code that would make the planned change easier to implement. Add a '## Preparatory Refactoring' section to `$PLAN_FILE` using the Edit tool. Share findings via SendMessage with severity levels. Mark task complete when done."
 
 **commit-planner teammate**:
 - `subagent_type`: "requirements-framework:commit-planner"
 - `name`: "commit-planner"
-- `prompt`: Include plan file content and instruction:
-  "Analyze this plan and generate an atomic commit strategy. Break the implementation into small, focused, independently-testable commits. For each commit: title, files changed, what to test. Append the commit strategy to the plan file using the Edit tool. Share a summary via SendMessage. Mark task complete when done."
+- `prompt`: Pass the plan file path `$PLAN_FILE` and instruction:
+  "Read the plan from `$PLAN_FILE`. Analyze this plan and generate an atomic commit strategy. Break the implementation into small, focused, independently-testable commits. For each commit: title, files changed, what to test. Append the commit strategy to `$PLAN_FILE` using the Edit tool. Share a summary via SendMessage. Mark task complete when done."
 
 **codex-arch-reviewer teammate** (ONLY if HAS_CODEX is true):
 - `subagent_type`: "requirements-framework:codex-arch-reviewer"
 - `name`: "codex-arch-reviewer"
-- `prompt`: Include plan file path and instruction:
-  "Analyze the architecture of the code changes on this branch using OpenAI Codex CLI. The plan file is at [PLAN_FILE_PATH]. Focus on coupling/cohesion, module dependencies, API surface design, scalability, and separation of concerns. Share findings via SendMessage with severity levels. Mark task complete when done."
+- `prompt`: Pass the plan file path `$PLAN_FILE` and instruction:
+  "Analyze the architecture of the code changes on this branch using OpenAI Codex CLI. The plan file is at `$PLAN_FILE`. Focus on coupling/cohesion, module dependencies, API surface design, scalability, and separation of concerns. Share findings via SendMessage with severity levels. Mark task complete when done."
 
 Launch all teammates in a SINGLE message (parallel execution).
 

--- a/plugins/requirements-framework/commands/arch-review.md
+++ b/plugins/requirements-framework/commands/arch-review.md
@@ -3,7 +3,7 @@ name: arch-review
 description: "Multi-perspective team-based architecture review with agent debate and commit planning"
 argument-hint: "[plan-file-path]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: f6369fe
+git_hash: ea8efe0
 ---
 
 # Architecture Review — Team-Based Multi-Perspective Assessment

--- a/plugins/requirements-framework/commands/brainstorm.md
+++ b/plugins/requirements-framework/commands/brainstorm.md
@@ -3,7 +3,7 @@ name: brainstorm
 description: "Design-first development: explore requirements before implementation"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 Invoke the `requirements-framework:brainstorming` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/brainstorm.md
+++ b/plugins/requirements-framework/commands/brainstorm.md
@@ -3,7 +3,7 @@ name: brainstorm
 description: "Design-first development: explore requirements before implementation"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 Invoke the `requirements-framework:brainstorming` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/codex-review.md
+++ b/plugins/requirements-framework/commands/codex-review.md
@@ -3,7 +3,7 @@ name: codex-review
 description: "AI-powered code review using OpenAI Codex"
 argument-hint: "[focus]"
 allowed-tools: ["Bash", "Task"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 # Codex AI Code Review

--- a/plugins/requirements-framework/commands/codex-review.md
+++ b/plugins/requirements-framework/commands/codex-review.md
@@ -3,7 +3,7 @@ name: codex-review
 description: "AI-powered code review using OpenAI Codex"
 argument-hint: "[focus]"
 allowed-tools: ["Bash", "Task"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 # Codex AI Code Review

--- a/plugins/requirements-framework/commands/commit-checks.md
+++ b/plugins/requirements-framework/commands/commit-checks.md
@@ -3,7 +3,7 @@ name: commit-checks
 description: "Auto-fix code quality issues - comment cleanup and import organization"
 argument-hint: "[--skip-autofix]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 # Pre-Commit Auto-Fix

--- a/plugins/requirements-framework/commands/commit-checks.md
+++ b/plugins/requirements-framework/commands/commit-checks.md
@@ -3,7 +3,7 @@ name: commit-checks
 description: "Auto-fix code quality issues - comment cleanup and import organization"
 argument-hint: "[--skip-autofix]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 # Pre-Commit Auto-Fix

--- a/plugins/requirements-framework/commands/deep-review.md
+++ b/plugins/requirements-framework/commands/deep-review.md
@@ -3,7 +3,7 @@ name: deep-review
 description: "Cross-validated team-based code review with agent debate"
 argument-hint: "[branch | a..b | PR#]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: 3786e5b
+git_hash: 068e1d5
 ---
 
 # Deep Review — Cross-Validated Team-Based Code Review

--- a/plugins/requirements-framework/commands/deep-review.md
+++ b/plugins/requirements-framework/commands/deep-review.md
@@ -3,7 +3,7 @@ name: deep-review
 description: "Cross-validated team-based code review with agent debate"
 argument-hint: "[branch | a..b | PR#]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: f6369fe
+git_hash: 3786e5b
 ---
 
 # Deep Review — Cross-Validated Team-Based Code Review

--- a/plugins/requirements-framework/commands/deep-review.md
+++ b/plugins/requirements-framework/commands/deep-review.md
@@ -1,7 +1,7 @@
 ---
 name: deep-review
 description: "Cross-validated team-based code review with agent debate"
-argument-hint: ""
+argument-hint: "[branch | a..b | PR#]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
 git_hash: f6369fe
 ---
@@ -16,18 +16,27 @@ Team-based review where agents cross-validate findings and produce a unified ver
 
 You MUST follow these steps in exact order. Do not skip steps or interpret - execute as written.
 
-### Step 1: Identify Changes to Review
+### Step 1: Resolve Review Scope
 
-Execute these bash commands:
+Execute this bash command:
 
 ```bash
-git diff --cached --name-only --diff-filter=ACMR > /tmp/deep_review_scope.txt 2>&1
-if [ ! -s /tmp/deep_review_scope.txt ]; then
-  git diff --name-only --diff-filter=ACMR > /tmp/deep_review_scope.txt 2>&1
-fi
+${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope "$ARGUMENTS"
 ```
 
-If /tmp/deep_review_scope.txt is empty: Output "No changes to review" and **EXIT**.
+The wrapper resolves `$ARGUMENTS` (empty / branch name / `a..b` range / PR number) and writes:
+- `/tmp/review_scope.txt` — one changed file per line
+- `/tmp/review.diff` — unified diff
+
+On success it prints a single `Scope: <source> (<N> files, base=<ref>)` line.
+
+If the wrapper exits non-zero (e.g., missing `gh` CLI for PR# argument, or base ref unavailable):
+- Output the wrapper's stderr message to the user
+- **STOP** — do not proceed with agent dispatch
+
+If `/tmp/review_scope.txt` is empty:
+- Output `No changes to review`
+- **STOP**
 
 ### Step 2: Check Conditional Agent Availability
 
@@ -39,7 +48,7 @@ Set flag:
 - **HAS_CODEX** = true if `which codex` succeeds (exit code 0)
 
 ```bash
-grep -qE '\.(tsx|jsx|css|scss)$' /tmp/deep_review_scope.txt 2>/dev/null
+grep -qE '\.(tsx|jsx|css|scss)$' /tmp/review_scope.txt 2>/dev/null
 ```
 
 Set flag:
@@ -92,6 +101,10 @@ For each review task (NOT the synthesis task), spawn a teammate via the Task too
 
 **Standard preamble for ALL teammate prompts** (include at the top of each prompt):
 ```
+You will review the scope in `/tmp/review_scope.txt` (changed files) and
+`/tmp/review.diff` (unified diff). Focus strictly on files in the scope.
+Do NOT run your own `git diff` — use the prepared scope files above.
+
 You MUST use the standard output format from ADR-013. All findings must use:
 - ### CRITICAL: [title] — for blocking issues
 - ### IMPORTANT: [title] — for significant concerns

--- a/plugins/requirements-framework/commands/execute-plan.md
+++ b/plugins/requirements-framework/commands/execute-plan.md
@@ -3,7 +3,7 @@ name: execute-plan
 description: "Execute implementation plan with batch checkpoints and review"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 Invoke the `requirements-framework:executing-plans` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/execute-plan.md
+++ b/plugins/requirements-framework/commands/execute-plan.md
@@ -3,7 +3,7 @@ name: execute-plan
 description: "Execute implementation plan with batch checkpoints and review"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 Invoke the `requirements-framework:executing-plans` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/plan-review.md
+++ b/plugins/requirements-framework/commands/plan-review.md
@@ -3,7 +3,7 @@ name: plan-review
 description: "Validate plan against ADRs, TDD, and SOLID principles, identify preparatory refactoring, then generate atomic commit strategy"
 argument-hint: "[plan-file]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 # Plan Review Command

--- a/plugins/requirements-framework/commands/plan-review.md
+++ b/plugins/requirements-framework/commands/plan-review.md
@@ -3,7 +3,7 @@ name: plan-review
 description: "Validate plan against ADRs, TDD, and SOLID principles, identify preparatory refactoring, then generate atomic commit strategy"
 argument-hint: "[plan-file]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 # Plan Review Command

--- a/plugins/requirements-framework/commands/pre-commit.md
+++ b/plugins/requirements-framework/commands/pre-commit.md
@@ -3,7 +3,7 @@ name: pre-commit
 description: "Quick code review before committing (code + error handling)"
 argument-hint: "[aspects]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 # Pre-Commit Review

--- a/plugins/requirements-framework/commands/pre-commit.md
+++ b/plugins/requirements-framework/commands/pre-commit.md
@@ -3,7 +3,7 @@ name: pre-commit
 description: "Quick code review before committing (code + error handling)"
 argument-hint: "[aspects]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelete", "SendMessage", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 # Pre-Commit Review

--- a/plugins/requirements-framework/commands/quality-check.md
+++ b/plugins/requirements-framework/commands/quality-check.md
@@ -1,7 +1,7 @@
 ---
 name: quality-check
 description: "Comprehensive quality review before creating PR"
-argument-hint: "[parallel]"
+argument-hint: "[branch | a..b | PR#]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 git_hash: f6369fe
 ---
@@ -31,38 +31,47 @@ Comprehensive code quality review before creating a pull request. This runs ALL 
 
 You MUST follow these steps in exact order. This is a comprehensive review - execute all steps precisely.
 
-### Step 1: Identify Changes to Review
+### Step 1: Resolve Review Scope
 
-Execute these bash commands:
+Execute this bash command:
 
 ```bash
-git diff --cached --name-only --diff-filter=ACMR > /tmp/pr_review_scope.txt 2>&1
-if [ ! -s /tmp/pr_review_scope.txt ]; then
-  git diff --name-only --diff-filter=ACMR > /tmp/pr_review_scope.txt 2>&1
-fi
+${CLAUDE_PLUGIN_ROOT}/scripts/prepare-diff-scope "$ARGUMENTS"
 ```
 
-If /tmp/pr_review_scope.txt is empty: Output "No changes to review" and EXIT.
+The wrapper resolves `$ARGUMENTS` (empty / branch name / `a..b` range / PR number) and writes:
+- `/tmp/review_scope.txt` — one changed file per line
+- `/tmp/review.diff` — unified diff
+
+On success it prints a single `Scope: <source> (<N> files, base=<ref>)` line.
+
+If the wrapper exits non-zero (e.g., missing `gh` CLI for PR# argument, or base ref unavailable):
+- Output the wrapper's stderr message to the user
+- **STOP** — do not proceed with agent dispatch
+
+If `/tmp/review_scope.txt` is empty:
+- Output `No changes to review`
+- **STOP**
 
 ### Step 2: Detect File Types and Set Applicability Flags
 
-Execute these detection commands to determine which agents apply:
+Execute these detection commands to determine which agents apply. They read the prepared scope files from Step 1 — do not re-run `git diff`.
 
 ```bash
 # Check for test files
-grep -E '(test_|_test\.py|\.test\.|\.spec\.)' /tmp/pr_review_scope.txt > /tmp/has_tests.txt 2>&1
+grep -E '(test_|_test\.py|\.test\.|\.spec\.)' /tmp/review_scope.txt > /tmp/has_tests.txt 2>&1 || true
 
 # Check for type definitions in the diff
-git diff --cached | grep -E '(class.*BaseModel|interface |type |dataclass|TypedDict|NamedTuple)' > /tmp/has_types.txt 2>&1
+grep -E '(class.*BaseModel|interface |type |dataclass|TypedDict|NamedTuple)' /tmp/review.diff > /tmp/has_types.txt 2>&1 || true
 
-# Check for comment changes
-git diff --cached --unified=0 | grep -E '^[+].*#|^[+].*//|^[+].*"""' > /tmp/has_comments.txt 2>&1
+# Check for comment changes (added comment lines in the diff)
+grep -E '^[+].*#|^[+].*//|^[+].*"""' /tmp/review.diff > /tmp/has_comments.txt 2>&1 || true
 
 # Check for schema/model changes (Pydantic, database models)
-git diff --cached | grep -E '(BaseModel|Field\(|Column\(|Table\(|alembic)' > /tmp/has_schemas.txt 2>&1
+grep -E '(BaseModel|Field\(|Column\(|Table\(|alembic)' /tmp/review.diff > /tmp/has_schemas.txt 2>&1 || true
 
 # Check for frontend files
-grep -E '\.(tsx|jsx|css|scss)$' /tmp/pr_review_scope.txt > /tmp/has_frontend.txt 2>&1 || true
+grep -E '\.(tsx|jsx|css|scss)$' /tmp/review_scope.txt > /tmp/has_frontend.txt 2>&1 || true
 ```
 
 Set applicability flags based on detection results:
@@ -79,12 +88,19 @@ Arguments received: "$ARGUMENTS"
 **PARALLEL_MODE**=false
 - Set to true if: $ARGUMENTS contains "parallel"
 
+**Standard preamble for ALL subagent prompts** (include at the top of each subagent prompt in Steps 4–8):
+
+```
+Read `/tmp/review_scope.txt` (changed files, one per line) and `/tmp/review.diff` (unified diff).
+Focus strictly on files in the scope. Do not run your own `git diff` — use the prepared scope files above.
+```
+
 ### Step 4: Execute Tool Validator - BLOCKING GATE (ALWAYS RUNS FIRST)
 
 This step is REQUIRED and MUST run before any other agents:
 
 1. Use the Task tool to launch subagent_type="requirements-framework:tool-validator"
-2. Pass context: File list from /tmp/pr_review_scope.txt
+2. Pass context: File list from /tmp/review_scope.txt
 3. Wait for completion
 4. Parse output for CRITICAL severity issues
 

--- a/plugins/requirements-framework/commands/quality-check.md
+++ b/plugins/requirements-framework/commands/quality-check.md
@@ -3,7 +3,7 @@ name: quality-check
 description: "Comprehensive quality review before creating PR"
 argument-hint: "[branch | a..b | PR#]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: 2b9aa9f
+git_hash: 068e1d5
 ---
 
 # Pre-PR Quality Check

--- a/plugins/requirements-framework/commands/quality-check.md
+++ b/plugins/requirements-framework/commands/quality-check.md
@@ -3,7 +3,7 @@ name: quality-check
 description: "Comprehensive quality review before creating PR"
 argument-hint: "[branch | a..b | PR#]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
-git_hash: f6369fe
+git_hash: 2b9aa9f
 ---
 
 # Pre-PR Quality Check

--- a/plugins/requirements-framework/commands/session-reflect.md
+++ b/plugins/requirements-framework/commands/session-reflect.md
@@ -3,7 +3,7 @@ name: session-reflect
 description: "Review current session and suggest improvements for future sessions"
 argument-hint: "[scope]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 # Session Learning Reflection

--- a/plugins/requirements-framework/commands/session-reflect.md
+++ b/plugins/requirements-framework/commands/session-reflect.md
@@ -3,7 +3,7 @@ name: session-reflect
 description: "Review current session and suggest improvements for future sessions"
 argument-hint: "[scope]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 # Session Learning Reflection

--- a/plugins/requirements-framework/commands/write-plan.md
+++ b/plugins/requirements-framework/commands/write-plan.md
@@ -3,7 +3,7 @@ name: write-plan
 description: "Create detailed implementation plan from requirements or spec"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: f6369fe
+git_hash: 5b1c418
 ---
 
 Invoke the `requirements-framework:writing-plans` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/write-plan.md
+++ b/plugins/requirements-framework/commands/write-plan.md
@@ -3,7 +3,7 @@ name: write-plan
 description: "Create detailed implementation plan from requirements or spec"
 argument-hint: ""
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUserQuestion"]
-git_hash: 5b1c418
+git_hash: 068e1d5
 ---
 
 Invoke the `requirements-framework:writing-plans` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/scripts/prepare-diff-scope
+++ b/plugins/requirements-framework/scripts/prepare-diff-scope
@@ -1,17 +1,26 @@
 #!/usr/bin/env bash
-# scripts/prepare-diff-scope
+# plugins/requirements-framework/scripts/prepare-diff-scope
 # Thin wrapper around hooks/lib/diff_scope.py for commands and agents.
 #
 # Usage:
-#   scripts/prepare-diff-scope "$ARGUMENTS"   # command-side (always runs)
-#   scripts/prepare-diff-scope --ensure       # agent-side (no-op if precomputed)
+#   prepare-diff-scope "$ARGUMENTS"   # command-side (always runs)
+#   prepare-diff-scope --ensure       # agent-side (no-op if precomputed)
 
 set -euo pipefail
 
-# Resolve the framework repo root from this script's location, not from cwd.
-# (The wrapper is typically invoked from inside some other project's working tree.)
+# Locate diff_scope.py. Search order:
+#   1. $HOME/.claude/hooks/lib            (deployed runtime — every framework user)
+#   2. $script_dir/../../../hooks/lib     (dev mode — running from source repo)
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(dirname "$script_dir")"
+if [[ -f "$HOME/.claude/hooks/lib/diff_scope.py" ]]; then
+  lib_dir="$HOME/.claude/hooks/lib"
+elif [[ -f "$script_dir/../../../hooks/lib/diff_scope.py" ]]; then
+  lib_dir="$(cd "$script_dir/../../../hooks/lib" && pwd)"
+else
+  echo "prepare-diff-scope: cannot find diff_scope.py. Run ./sync.sh deploy or install the framework." >&2
+  exit 3
+fi
+
 py="python3"
 
 case "${1:-}" in
@@ -22,7 +31,7 @@ case "${1:-}" in
     fi
     "$py" -c "
 import sys
-sys.path.insert(0, '$repo_root/hooks/lib')
+sys.path.insert(0, '$lib_dir')
 from diff_scope import ensure_scope
 s = ensure_scope()
 print(f'Scope: {s.source} ({len(s.files)} files, base={s.base_ref or \"(none)\"})')
@@ -32,7 +41,7 @@ print(f'Scope: {s.source} ({len(s.files)} files, base={s.base_ref or \"(none)\"}
     arg="${1:-}"
     "$py" -c "
 import sys
-sys.path.insert(0, '$repo_root/hooks/lib')
+sys.path.insert(0, '$lib_dir')
 from diff_scope import prepare_diff_scope, base_from_config, DiffScopeError
 try:
     s = prepare_diff_scope('$arg' or None, base=base_from_config())

--- a/scripts/prepare-diff-scope
+++ b/scripts/prepare-diff-scope
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# scripts/prepare-diff-scope
+# Thin wrapper around hooks/lib/diff_scope.py for commands and agents.
+#
+# Usage:
+#   scripts/prepare-diff-scope "$ARGUMENTS"   # command-side (always runs)
+#   scripts/prepare-diff-scope --ensure       # agent-side (no-op if precomputed)
+
+set -euo pipefail
+
+# Resolve the framework repo root from this script's location, not from cwd.
+# (The wrapper is typically invoked from inside some other project's working tree.)
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(dirname "$script_dir")"
+py="python3"
+
+case "${1:-}" in
+  --ensure)
+    # Silent no-op if both files exist non-empty
+    if [[ -s /tmp/review_scope.txt && -s /tmp/review.diff ]]; then
+      exit 0
+    fi
+    "$py" -c "
+import sys
+sys.path.insert(0, '$repo_root/hooks/lib')
+from diff_scope import ensure_scope
+s = ensure_scope()
+print(f'Scope: {s.source} ({len(s.files)} files, base={s.base_ref or \"(none)\"})')
+"
+    ;;
+  *)
+    arg="${1:-}"
+    "$py" -c "
+import sys
+sys.path.insert(0, '$repo_root/hooks/lib')
+from diff_scope import prepare_diff_scope, base_from_config, DiffScopeError
+try:
+    s = prepare_diff_scope('$arg' or None, base=base_from_config())
+    print(f'Scope: {s.source} ({len(s.files)} files, base={s.base_ref or \"(none)\"})')
+except DiffScopeError as e:
+    print(f'Cannot resolve scope: {e}', file=sys.stderr)
+    sys.exit(2)
+"
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adopts two patterns from solarmonkey's `tino/agent-guidance-via-docs` branch (see `docs/plans/2026-04-21-diff-scope-refactor-design.md` for the framework-alignment review that originated this work):

- **Pre-compute diff once** — new `hooks/lib/diff_scope.py` resolves review scope in one place. Commands (`/deep-review`, `/quality-check`) call the helper; 13 review agents read the pre-computed `/tmp/review_scope.txt` + `/tmp/review.diff` instead of running their own `git diff`.
- **Multi-input scope resolution** — `/deep-review` and `/quality-check` now accept a branch name, a git range (`a..b` / `a...b`), or a PR number (`1234` / `#1234`) as argument. Empty falls back to staged → unstaged → branch-vs-base.
- **`/arch-review` plan-file argument** — accepts a path, falls back to the most recent plan under `docs/plans/`, `.claude/plans/`, or `~/.claude/plans/`.

Breaking change — plugin bumps `2.8.2 → 3.0.0`. See CHANGELOG.md for migration notes.

## Highlights

- `hooks/lib/diff_scope.py` — 263 lines, 31 unit tests in `hooks/test_diff_scope.py` using real fixture git repos (plus fake-gh shim for PR-path tests)
- `plugins/requirements-framework/scripts/prepare-diff-scope` — thin bash wrapper with dual-location `diff_scope.py` discovery (deployed runtime vs dev-mode repo layout)
- 13 agents unified on a single Step 1 block → net `-55` lines of agent boilerplate
- Fixed two pre-existing silent-failure bugs caught in code review: `--diff-filter=ACMRD` now includes deletions; base ref is validated before diffing

## Test Plan

- [x] `python3 hooks/test_diff_scope.py` — 31/31 passed
- [x] `python3 hooks/test_requirements.py` — 1229/1229 passed
- [x] `python3 hooks/test_branch_size_calculator.py` — 18/18 passed
- [x] Manual smoke: `scripts/prepare-diff-scope --ensure` on a dirty tree writes both files and exits 0
- [ ] Dogfood `/deep-review feat/diff-scope-refactor` (new branch-name path)
- [ ] Dogfood `/deep-review <PR#>` once this PR exists (new PR# path)
- [ ] Verify agent Step 1 on a real multi-file review (13 agents should all produce findings against `/tmp/review_scope.txt`)

## Open follow-ups (not in this PR)

- `comment-cleaner` + `import-organizer` auto-fixers intentionally excluded from the refactor — they want staged-only semantics. See task #7.
- `/quality-check` parallel-mode dispatch is now dead code (first positional arg is consumed as scope). See task #24 and CHANGELOG known-limitation.
- Consider an ADR for the 3.0.0 agent-contract break.