### PR TITLE
refactor: simplification stack (workflow-index, statusline, /req)

### DIFF
--- a/docs/STATUSLINE.md
+++ b/docs/STATUSLINE.md
@@ -1,0 +1,99 @@
+# Phase-aware statusline
+
+A one-line, always-visible status injected into Claude Code's status bar. It
+turns the question "what should I do next?" into something you can *see*
+instead of asking the model.
+
+## Format
+
+```
+[phase] [ctx N%] [$cost] [N req⬜]
+```
+
+| Field    | Meaning                                                      |
+|----------|--------------------------------------------------------------|
+| `phase`  | Derived workflow phase: `design`, `plan`, `implement`, `review`, `ship`, or `?` when outside a git repo |
+| `ctx N%` | Input-side context window usage reported by Claude Code     |
+| `$cost`  | Session cost in USD                                          |
+| `N req⬜` | Count of triggered-but-unsatisfied requirements             |
+
+## Phase derivation
+
+`hooks/lib/derive_phase.py` walks an ordered list of gating requirements and
+returns the first that is *not* satisfied:
+
+| Phase           | Gating requirement       |
+|-----------------|--------------------------|
+| `design`        | `design_approved`        |
+| `plan-write`    | `plan_written`           |
+| `plan-validate` | `solid_reviewed`         |
+| `implement`     | `verification_evidence`  |
+| `review`        | `pre_pr_review`          |
+| `ship`          | everything above satisfied |
+
+Planning is split into two phases because two skills are needed to clear all planning gates: `/write-plan` flips `plan_written` (advances `plan-write` → `plan-validate`), then `/arch-review` flips `commit_plan` / `adr_reviewed` / `tdd_planned` / `solid_reviewed` together (advances `plan-validate` → `implement`).
+
+The statusline runs without a session ID, so a requirement counts as
+"satisfied" if **any session** has satisfied it, *or* if there is a
+branch-level satisfaction record. This matches the
+`workflow-index` skill's definitions.
+
+The same logic is reusable from Python: `derive_phase(Path(state_file))`.
+
+## Performance
+
+Warm execution runs in ~200–300ms on macOS, dominated by Python interpreter
+startup (`statusline_data.py` collapses two CLI calls into one). This is
+below the perceptible-lag threshold for a statusline that refreshes on a
+timer; it is comfortably above the aspirational 100ms target named in the
+original plan. Switching to pure jq would cut runtime to ~50ms at the cost
+of duplicating the phase-mapping in two languages — not worth it while the
+same mapping is needed in Python for the `/req` conductor.
+
+## Installation
+
+`./install.sh` registers the statusline in `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/plugins/requirements-framework/statusline.sh"
+  }
+}
+```
+
+The installer only writes this when `statusLine` is absent — your custom
+statusline, if any, is preserved.
+
+## Customization
+
+To use your own statusline, edit `~/.claude/settings.json` directly. The
+script is plain bash and accepts the JSON Claude Code emits on stdin:
+
+- `.workspace.current_dir` — cwd, used to find the git branch
+- `.context_window.used_percentage` — context %
+- `.session.cost_usd` — session cost
+
+To extend the line (e.g., add a git-dirty marker), copy
+`statusline.sh` to your own location, modify it, and point the
+`command` at your copy.
+
+## Failure modes
+
+The script is fail-open: any error degrades a single field to `?` rather
+than failing the whole line. If you see `[?]` somewhere unexpectedly:
+
+| Symptom                | Likely cause                                |
+|------------------------|---------------------------------------------|
+| `[? req⬜]`             | Outside a git repo, or no `.git/requirements/` state |
+| `[design]` always      | `derive_phase.py` couldn't read the state file |
+| Blank statusline       | `jq` or `python3` missing on `$PATH`        |
+
+## Related
+
+- `hooks/lib/derive_phase.py` — pure function returning the phase name
+- `hooks/lib/count_unsatisfied.py` — pure function returning the count
+- `hooks/lib/statusline_data.py` — combined CLI used by `statusline.sh`
+- `plugins/requirements-framework/skills/workflow-index/SKILL.md` — the
+  human-readable map of phases the model uses when guiding the user

--- a/docs/STATUSLINE.md
+++ b/docs/STATUSLINE.md
@@ -12,7 +12,7 @@ instead of asking the model.
 
 | Field    | Meaning                                                      |
 |----------|--------------------------------------------------------------|
-| `phase`  | Derived workflow phase: `design`, `plan`, `implement`, `review`, `ship`, or `?` when outside a git repo |
+| `phase`  | Derived workflow phase: `design`, `plan-write`, `plan-validate`, `implement`, `review`, `ship`, or `?` when outside a git repo |
 | `ctx N%` | Input-side context window usage reported by Claude Code     |
 | `$cost`  | Session cost in USD                                          |
 | `N req⬜` | Count of triggered-but-unsatisfied requirements             |

--- a/hooks/lib/count_unsatisfied.py
+++ b/hooks/lib/count_unsatisfied.py
@@ -1,0 +1,75 @@
+"""Count unsatisfied (but triggered) requirements for the statusline.
+
+Pure function. A requirement counts as unsatisfied when it has been
+*triggered* at the branch or any session level but is not yet satisfied
+at either branch or any session level.
+
+CLI usage:
+    python3 count_unsatisfied.py <state-file-path>
+prints an integer to stdout. Exits 0 even on errors (fail-open).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _is_triggered(req_state: object) -> bool:
+    if not isinstance(req_state, dict):
+        return False
+    if req_state.get("triggered"):
+        return True
+    sessions = req_state.get("sessions")
+    if not isinstance(sessions, dict):
+        return False
+    return any(
+        isinstance(sess, dict) and sess.get("triggered")
+        for sess in sessions.values()
+    )
+
+
+def _is_satisfied(req_state: object) -> bool:
+    if not isinstance(req_state, dict):
+        return False
+    if req_state.get("satisfied") is True:
+        return True
+    sessions = req_state.get("sessions")
+    if not isinstance(sessions, dict):
+        return False
+    return any(
+        isinstance(sess, dict) and sess.get("satisfied")
+        for sess in sessions.values()
+    )
+
+
+def count_unsatisfied(state_file: Path) -> int:
+    if not state_file.is_file():
+        return 0
+    try:
+        data = json.loads(state_file.read_text())
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return 0
+    if not isinstance(data, dict):
+        return 0
+    reqs = data.get("requirements")
+    if not isinstance(reqs, dict):
+        return 0
+    return sum(
+        1
+        for req_state in reqs.values()
+        if _is_triggered(req_state) and not _is_satisfied(req_state)
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(0)
+        return 0
+    print(count_unsatisfied(Path(argv[1])))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hooks/lib/derive_phase.py
+++ b/hooks/lib/derive_phase.py
@@ -1,0 +1,83 @@
+"""Derive the workflow phase from a requirement state file.
+
+Pure function: reads a JSON state file path, returns one of the
+phase names defined in the workflow-index skill. Used by the
+statusline (which has no session context) and by the /req conductor.
+
+Phase order is top-to-bottom; the first unsatisfied gate wins.
+If everything is satisfied, the phase is `ship`.
+
+CLI usage:
+    python3 derive_phase.py <state-file-path>
+prints the phase name to stdout. Exits 0 even on errors (fail-open).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Order matters: first unsatisfied wins.
+# plan-write satisfies plan_written; plan-validate is gated on solid_reviewed
+# (which arch-review flips alongside commit_plan, adr_reviewed, tdd_planned).
+PHASE_GATES: list[tuple[str, str]] = [
+    ("design", "design_approved"),
+    ("plan-write", "plan_written"),
+    ("plan-validate", "solid_reviewed"),
+    ("implement", "verification_evidence"),
+    ("review", "pre_pr_review"),
+]
+SHIP_PHASE = "ship"
+DEFAULT_PHASE = "design"
+
+
+def _is_satisfied(req_state: object) -> bool:
+    """True if the requirement is satisfied at branch or any session level.
+
+    Treats ANY session-level satisfaction as "this phase has been completed,"
+    because the caller has no session context. Defensive against schema drift —
+    any non-dict input returns False rather than raising.
+    """
+    if not isinstance(req_state, dict):
+        return False
+    if req_state.get("satisfied") is True:
+        return True
+    sessions = req_state.get("sessions")
+    if not isinstance(sessions, dict):
+        return False
+    return any(
+        isinstance(sess, dict) and sess.get("satisfied")
+        for sess in sessions.values()
+    )
+
+
+def derive_phase(state_file: Path) -> str:
+    """Return the current phase name for the project at this state file."""
+    if not state_file.is_file():
+        return DEFAULT_PHASE
+    try:
+        data = json.loads(state_file.read_text())
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return DEFAULT_PHASE
+    if not isinstance(data, dict):
+        return DEFAULT_PHASE
+    reqs = data.get("requirements")
+    if not isinstance(reqs, dict):
+        return DEFAULT_PHASE
+    for phase_name, req_name in PHASE_GATES:
+        if not _is_satisfied(reqs.get(req_name)):
+            return phase_name
+    return SHIP_PHASE
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(DEFAULT_PHASE)
+        return 0
+    print(derive_phase(Path(argv[1])))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hooks/lib/statusline_data.py
+++ b/hooks/lib/statusline_data.py
@@ -1,0 +1,37 @@
+"""Combined statusline data CLI.
+
+Wraps derive_phase() and count_unsatisfied() in one entry point so the
+shell statusline can fetch both values with a single python3 invocation
+(Python startup is the dominant cost — two invocations doubles the lag).
+
+CLI usage:
+    python3 statusline_data.py <state-file-path>
+prints `<phase> <unsatisfied_count>` on one line. Fail-open on errors.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from count_unsatisfied import count_unsatisfied
+from derive_phase import DEFAULT_PHASE, derive_phase
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(f"{DEFAULT_PHASE} 0")
+        return 0
+    try:
+        p = Path(argv[1])
+        print(f"{derive_phase(p)} {count_unsatisfied(p)}")
+    except Exception:
+        # Last-resort fail-open: the statusline must never crash on a malformed
+        # state file. Helpers already guard their own paths; this catches
+        # anything that slips through (PermissionError, unexpected types, etc.).
+        print(f"{DEFAULT_PHASE} 0")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hooks/test_requirements.py
+++ b/hooks/test_requirements.py
@@ -10886,6 +10886,136 @@ def test_obsidian_session_logger(runner: TestRunner):
                     f"Got: {popen_args[1]}")
 
 
+def test_derive_phase(runner: TestRunner):
+    """Test workflow-phase derivation from requirement state files."""
+    print("\n📦 Testing derive_phase module...")
+    from derive_phase import derive_phase, DEFAULT_PHASE, SHIP_PHASE
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+
+        runner.test("missing file → DEFAULT_PHASE",
+                    derive_phase(tmp / "nope.json") == DEFAULT_PHASE)
+
+        bad = tmp / "bad.json"
+        bad.write_text("{not json")
+        runner.test("malformed JSON → DEFAULT_PHASE",
+                    derive_phase(bad) == DEFAULT_PHASE)
+
+        empty = tmp / "empty.json"
+        empty.write_text('{"requirements": {}}')
+        runner.test("empty requirements → design",
+                    derive_phase(empty) == "design")
+
+        def _state(satisfied_reqs: dict[str, str]) -> Path:
+            reqs: dict = {}
+            for name, mode in satisfied_reqs.items():
+                if mode == "branch":
+                    reqs[name] = {"satisfied": True}
+                elif mode == "session":
+                    reqs[name] = {"sessions": {"abc": {"satisfied": True}}}
+            fixture_id = "_".join(sorted(satisfied_reqs)) or "empty"
+            f = tmp / f"state-{fixture_id}.json"
+            f.write_text(json.dumps({"requirements": reqs}))
+            return f
+
+        runner.test("design_approved sat → plan-write",
+                    derive_phase(_state({"design_approved": "session"})) == "plan-write")
+
+        runner.test("plan-write sat → plan-validate",
+                    derive_phase(_state({
+                        "design_approved": "session",
+                        "plan_written": "branch",
+                    })) == "plan-validate")
+
+        runner.test("plan-validate sat → implement",
+                    derive_phase(_state({
+                        "design_approved": "session",
+                        "plan_written": "session",
+                        "solid_reviewed": "session",
+                    })) == "implement")
+
+        runner.test("through verification → review",
+                    derive_phase(_state({
+                        "design_approved": "session",
+                        "plan_written": "session",
+                        "solid_reviewed": "session",
+                        "verification_evidence": "session",
+                    })) == "review")
+
+        runner.test("everything sat → ship",
+                    derive_phase(_state({
+                        "design_approved": "session",
+                        "plan_written": "session",
+                        "solid_reviewed": "session",
+                        "verification_evidence": "session",
+                        "pre_pr_review": "branch",
+                    })) == SHIP_PHASE)
+
+        # Mixed: one session satisfied, others not → still counts as satisfied
+        mixed = tmp / "mixed.json"
+        mixed.write_text(json.dumps({"requirements": {
+            "design_approved": {"sessions": {
+                "old": {"satisfied": False},
+                "new": {"satisfied": True},
+            }},
+        }}))
+        runner.test("any-session-satisfied counts as satisfied",
+                    derive_phase(mixed) == "plan-write")
+
+        # Schema robustness: malformed structures should fail-open, not raise.
+        for label, content in [
+            ("requirements: null", '{"requirements": null}'),
+            ("requirements: list", '{"requirements": []}'),
+            ("req entry: null", '{"requirements": {"design_approved": null}}'),
+            ("sessions: null", '{"requirements": {"design_approved": {"sessions": null}}}'),
+            ("top-level: list", '[]'),
+        ]:
+            f = tmp / f"bad-{label.replace(': ', '-').replace(' ', '_')}.json"
+            f.write_text(content)
+            runner.test(f"defensive: {label} → DEFAULT_PHASE",
+                        derive_phase(f) == DEFAULT_PHASE)
+
+
+def test_count_unsatisfied(runner: TestRunner):
+    """Test count_unsatisfied helper."""
+    print("\n📦 Testing count_unsatisfied module...")
+    from count_unsatisfied import count_unsatisfied
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+
+        runner.test("missing file → 0",
+                    count_unsatisfied(tmp / "nope.json") == 0)
+
+        bad = tmp / "bad.json"
+        bad.write_text("nope")
+        runner.test("malformed → 0",
+                    count_unsatisfied(bad) == 0)
+
+        empty = tmp / "empty.json"
+        empty.write_text('{"requirements": {}}')
+        runner.test("empty → 0",
+                    count_unsatisfied(empty) == 0)
+
+        mix = tmp / "mix.json"
+        mix.write_text(json.dumps({"requirements": {
+            # Triggered + not satisfied (counts).
+            "a": {"sessions": {"s1": {"triggered": True}}},
+            # Triggered + satisfied (excluded).
+            "b": {"sessions": {"s1": {"triggered": True, "satisfied": True}}},
+            # Branch-level satisfied (excluded).
+            "c": {"triggered": True, "satisfied": True},
+            # Branch-level triggered, not satisfied (counts).
+            "d": {"triggered": True},
+            # Not triggered (excluded).
+            "e": {"sessions": {"s1": {"satisfied": False}}},
+        }}))
+        runner.test("counts only triggered-and-unsatisfied",
+                    count_unsatisfied(mix) == 2,
+                    f"Got: {count_unsatisfied(mix)}")
+
+
 def main():
     """Run all tests."""
     print("🧪 Requirements Framework Test Suite")
@@ -11082,6 +11212,9 @@ def main():
     # Obsidian CLI integration tests
     test_obsidian_client(runner)
     test_obsidian_session_logger(runner)
+
+    test_derive_phase(runner)
+    test_count_unsatisfied(runner)
 
     return runner.summary()
 

--- a/install.sh
+++ b/install.sh
@@ -473,6 +473,19 @@ try:
     # Ensure disableAllHooks is false
     settings["disableAllHooks"] = False
 
+    # Register the phase-aware statusline, but never clobber a user's
+    # existing statusLine — only fill it in when absent or empty.
+    STATUSLINE_CMD = "~/.claude/plugins/requirements-framework/statusline.sh"
+    existing_status = settings.get("statusLine") or {}
+    existing_cmd = existing_status.get("command", "")
+    if not existing_cmd:
+        settings["statusLine"] = {"type": "command", "command": STATUSLINE_CMD}
+        print("   ✅ Statusline registered")
+    elif "requirements-framework/statusline.sh" in existing_cmd:
+        print("   ✅ Statusline already registered")
+    else:
+        print("   ℹ️  Existing statusLine preserved (custom command detected)")
+
     with open(settings_file, 'w') as f:
         json.dump(settings, f, indent=2)
 

--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "Claude Code Requirements Framework - Complete development lifecycle from ideation to completion. Enforces workflow requirements through hooks, guides process with 19 development skills (brainstorming, TDD, debugging, verification), and provides comprehensive code review agents.",
   "author": {
     "name": "Harm"

--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Claude Code Requirements Framework - Complete development lifecycle from ideation to completion. Enforces workflow requirements through hooks, guides process with 19 development skills (brainstorming, TDD, debugging, verification), and provides comprehensive code review agents.",
   "author": {
     "name": "Harm"

--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Claude Code Requirements Framework - Complete development lifecycle from ideation to completion. Enforces workflow requirements through hooks, guides process with 19 development skills (brainstorming, TDD, debugging, verification), and provides comprehensive code review agents.",
   "author": {
     "name": "Harm"

--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Claude Code Requirements Framework - Complete development lifecycle from ideation to completion. Enforces workflow requirements through hooks, guides process with 19 development skills (brainstorming, TDD, debugging, verification), and provides comprehensive code review agents.",
   "author": {
     "name": "Harm"

--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Claude Code Requirements Framework - Complete development lifecycle from ideation to completion. Enforces workflow requirements through hooks, guides process with 19 development skills (brainstorming, TDD, debugging, verification), and provides comprehensive code review agents.",
   "author": {
     "name": "Harm"

--- a/plugins/requirements-framework/agents/code-simplifier.md
+++ b/plugins/requirements-framework/agents/code-simplifier.md
@@ -1,6 +1,6 @@
 ---
 name: code-simplifier
-description: Use this agent to simplify code after passing review, before final commit. This agent simplifies code by following project best practices while retaining all functionality. It focuses on recently modified code unless instructed otherwise.
+description: DEPRECATED — overlaps with code-reviewer; will be removed in a future major release. Use this agent to simplify code after passing review, before final commit. This agent simplifies code by following project best practices while retaining all functionality. It focuses on recently modified code unless instructed otherwise.
 
 <example>
 Context: After code passes review.

--- a/plugins/requirements-framework/commands/arch-review.md
+++ b/plugins/requirements-framework/commands/arch-review.md
@@ -6,6 +6,8 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelet
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: invoked by `/req plan`. Run directly to override the conductor.
+
 # Architecture Review — Team-Based Multi-Perspective Assessment
 
 Team-based architecture review where agents debate architectural implications of a plan and generate an atomic commit strategy.

--- a/plugins/requirements-framework/commands/brainstorm.md
+++ b/plugins/requirements-framework/commands/brainstorm.md
@@ -6,4 +6,6 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUse
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: invoked by `/req design`. Run directly to override the conductor.
+
 Invoke the `requirements-framework:brainstorming` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/codex-review.md
+++ b/plugins/requirements-framework/commands/codex-review.md
@@ -6,6 +6,8 @@ allowed-tools: ["Bash", "Task"]
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: suggested by `/req ship` after `/req review`, as the second-opinion external review. Run directly any time for an independent AI check.
+
 # Codex AI Code Review
 
 Run OpenAI Codex AI code review on your changes.

--- a/plugins/requirements-framework/commands/commit-checks.md
+++ b/plugins/requirements-framework/commands/commit-checks.md
@@ -6,6 +6,8 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: auto-fix utility used during `/req implement`. Run directly to clean up imports and comments before committing.
+
 # Pre-Commit Auto-Fix
 
 Runs 2 auto-fix agents to clean up code before committing. Comments are cleaned and imports are organized, then changes are re-staged.

--- a/plugins/requirements-framework/commands/deep-review.md
+++ b/plugins/requirements-framework/commands/deep-review.md
@@ -6,6 +6,8 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelet
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: invoked by `/req review`. Run directly to override the conductor.
+
 # Deep Review — Cross-Validated Team-Based Code Review
 
 Team-based review where agents cross-validate findings and produce a unified verdict.

--- a/plugins/requirements-framework/commands/execute-plan.md
+++ b/plugins/requirements-framework/commands/execute-plan.md
@@ -6,4 +6,6 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUse
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: invoked by `/req implement`. Run directly to override the conductor.
+
 Invoke the `requirements-framework:executing-plans` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/commands/plan-review.md
+++ b/plugins/requirements-framework/commands/plan-review.md
@@ -1,6 +1,6 @@
 ---
 name: plan-review
-description: "Validate plan against ADRs, TDD, and SOLID principles, identify preparatory refactoring, then generate atomic commit strategy"
+description: "DEPRECATED — use /arch-review (team-based) or /req plan (conductor). Will be removed in a future major release. Validates plan against ADRs, TDD, and SOLID principles, identifies preparatory refactoring, then generates atomic commit strategy."
 argument-hint: "[plan-file]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 git_hash: 2f4cfb2

--- a/plugins/requirements-framework/commands/plan-review.md
+++ b/plugins/requirements-framework/commands/plan-review.md
@@ -6,6 +6,8 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: lightweight alternative to `/req plan` (sequential review, no agent debate). Run directly when a quick check suffices.
+
 # Plan Review Command
 
 > **For thorough multi-perspective review with agent cross-validation, use `/arch-review` instead.**

--- a/plugins/requirements-framework/commands/pre-commit.md
+++ b/plugins/requirements-framework/commands/pre-commit.md
@@ -6,6 +6,8 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task", "TeamCreate", "TeamDelet
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: lightweight pre-commit alternative to `/req review`. Run directly before each commit.
+
 # Pre-Commit Review
 
 Run focused code quality checks on unstaged/staged changes before committing.

--- a/plugins/requirements-framework/commands/quality-check.md
+++ b/plugins/requirements-framework/commands/quality-check.md
@@ -6,6 +6,8 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: lightweight alternative to `/req review` (faster, no agent debate). Run directly when a quick check suffices.
+
 # Pre-PR Quality Check
 
 > **For cross-validated review with agent debate, use `/deep-review` instead.**

--- a/plugins/requirements-framework/commands/quality-check.md
+++ b/plugins/requirements-framework/commands/quality-check.md
@@ -1,6 +1,6 @@
 ---
 name: quality-check
-description: "Comprehensive quality review before creating PR"
+description: "DEPRECATED — use /deep-review (team-based) or /req review (conductor). Will be removed in a future major release. Runs a comprehensive quality review before creating a PR."
 argument-hint: "[branch | a..b | PR#]"
 allowed-tools: ["Bash", "Glob", "Grep", "Read", "Task"]
 git_hash: 2f4cfb2

--- a/plugins/requirements-framework/commands/refactor-orchestrate.md
+++ b/plugins/requirements-framework/commands/refactor-orchestrate.md
@@ -6,6 +6,8 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUse
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: invoked by `/req refactor`. Run directly to override the conductor.
+
 # Refactor Orchestration — Deterministic Orchestrator
 
 Multi-layer top-down refactor workflow. Satisfies no framework requirements (run `/requirements-framework:arch-review` first if your project enforces planning gates).

--- a/plugins/requirements-framework/commands/req.md
+++ b/plugins/requirements-framework/commands/req.md
@@ -1,0 +1,55 @@
+---
+name: req
+description: "Workflow conductor — derives the current requirements-framework phase and dispatches to the matching skill/command. Run with no arguments to be guided, or pass an explicit phase: design, plan-write, plan-validate, implement, review, refactor, ship. Also accepts `plan` as a friendly alias that auto-picks the active plan sub-phase."
+argument-hint: "[phase]"
+allowed-tools: ["Bash", "Read", "Skill"]
+git_hash: uncommitted
+---
+
+# `/req` — Workflow Conductor
+
+You are the requirements-framework workflow conductor. Your job is to (1) resolve the **current phase**, (2) tell the user *which* command/skill matches that phase and *why*, and (3) invoke it. Do not perform the phase's work yourself — delegate.
+
+## Step 1 — Resolve the phase
+
+If `$ARGUMENTS` is one of `design`, `plan-write`, `plan-validate`, `implement`, `review`, `refactor`, or `ship`, use that value as the phase. Skip to Step 2.
+
+If `$ARGUMENTS` is the friendly alias `plan`, resolve it: derive the current phase (next step) and treat it as `plan-write` if `plan_written` is unsatisfied, otherwise `plan-validate`.
+
+Otherwise, derive the phase by running:
+
+```
+${CLAUDE_PLUGIN_ROOT}/scripts/req-phase
+```
+
+That script prints a single word — the phase — to stdout. Capture it.
+
+## Step 2 — Dispatch
+
+Look up the resolved phase in this table and act:
+
+| Phase         | Underlying skill                                | What to do                                                  |
+|---------------|-------------------------------------------------|-------------------------------------------------------------|
+| design        | `requirements-framework:brainstorming`          | Invoke the skill with the Skill tool                        |
+| plan-write    | `requirements-framework:writing-plans`          | Invoke the skill with the Skill tool                        |
+| plan-validate | `requirements-framework:arch-review`            | Invoke the skill with the Skill tool                        |
+| implement     | `requirements-framework:executing-plans`        | Invoke the skill with the Skill tool                        |
+| review        | `requirements-framework:deep-review`            | Invoke the skill with the Skill tool                        |
+| refactor      | `requirements-framework:refactor-orchestration` | Invoke the skill with the Skill tool                        |
+| ship          | *(none)*                                        | Report status and suggest the user finalize commits + open a PR |
+
+Before invoking, send the user a single line announcing the dispatch decision, like:
+
+> Phase is **plan-validate** — invoking `requirements-framework:arch-review`.
+
+Then invoke the skill via the `Skill` tool.
+
+## Step 3 — After dispatch
+
+The target skill takes over from here. Do not continue the workflow yourself in this turn — your job is over once the dispatch happens. The skill (and the framework hooks that listen for its completion) will flip the next requirement, which moves the project to the next phase. The user can rerun `/req` to advance.
+
+## Notes
+
+- This is a **deterministic dispatcher**, not an agent. It does not negotiate, summarize, or improvise — it routes attention to the right next step.
+- The phase mapping mirrors the `workflow-index` skill exactly. If the two ever drift, the index is the human-readable source of truth; this command is the executable one.
+- For the `ship` phase, there is no single canonical skill — the user typically wraps up with `/requirements-framework:codex-review` and a PR. Surface those as suggestions but do not invoke them automatically; shipping is a decision the user makes.

--- a/plugins/requirements-framework/commands/session-reflect.md
+++ b/plugins/requirements-framework/commands/session-reflect.md
@@ -6,6 +6,8 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUse
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: retrospective tool, not part of the `/req` phase pipeline. Run directly at the end of a session to harvest learnings.
+
 # Session Learning Reflection
 
 Analyze the current session to identify patterns, friction points, and improvement opportunities. Updates memories, skills, and commands to make future sessions more efficient.

--- a/plugins/requirements-framework/commands/write-plan.md
+++ b/plugins/requirements-framework/commands/write-plan.md
@@ -6,4 +6,6 @@ allowed-tools: ["Bash", "Glob", "Grep", "Read", "Write", "Edit", "Task", "AskUse
 git_hash: 2f4cfb2
 ---
 
+> **Workflow position**: invoked by `/req plan` (writing phase). Run directly to override the conductor.
+
 Invoke the `requirements-framework:writing-plans` skill and follow it exactly as presented to you.

--- a/plugins/requirements-framework/scripts/req-phase
+++ b/plugins/requirements-framework/scripts/req-phase
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# plugins/requirements-framework/scripts/req-phase
+# Thin wrapper around hooks/lib/derive_phase.py for the /req command.
+#
+# Prints the current workflow phase to stdout. Exits 0 even on errors
+# (fail-open) — the statusline and conductor must never refuse to run.
+#
+# Usage:
+#   req-phase
+# Output: one of design | plan-write | plan-validate | implement | review | ship
+
+set -uo pipefail
+
+# Locate derive_phase.py. Search order:
+#   1. $HOME/.claude/hooks/lib  (deployed runtime — every framework user)
+#   2. $script_dir/../../../hooks/lib  (dev mode — source repo)
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$HOME/.claude/hooks/lib/derive_phase.py" ]]; then
+  lib_dir="$HOME/.claude/hooks/lib"
+elif [[ -f "$script_dir/../../../hooks/lib/derive_phase.py" ]]; then
+  lib_dir="$(cd "$script_dir/../../../hooks/lib" && pwd)"
+else
+  echo "design"
+  exit 0
+fi
+
+# Find the current branch's state file using the same mangling the
+# framework uses internally (slash → dash, then alnum/dash/underscore).
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [[ -z "$branch" ]]; then
+  echo "design"
+  exit 0
+fi
+safe_branch=$(printf '%s' "$branch" | tr '/\\' '--' | tr -c '[:alnum:]_-' '_')
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+state_file="$repo_root/.git/requirements/${safe_branch}.json"
+
+PYTHONPATH="$lib_dir" python3 "$lib_dir/derive_phase.py" "$state_file" 2>/dev/null \
+  || echo "design"

--- a/plugins/requirements-framework/skills/workflow-index/SKILL.md
+++ b/plugins/requirements-framework/skills/workflow-index/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: workflow-index
+description: Use this skill at the start of any non-trivial work in a project that uses the requirements-framework. It maps the current phase to the single next command to run. Triggers on "what next", "where am I", "/req", or when the user is uncertain what workflow to use.
+git_hash: uncommitted
+---
+
+# Workflow Index
+
+The requirements-framework workflow is a 7-phase pipeline. At any moment, your project is in exactly one phase, derived from requirement state.
+
+## Phase → next command
+
+| Phase | When | Run |
+|-------|------|-----|
+| design | `design_approved` unsatisfied | `/brainstorm` |
+| plan-write | `plan_written` unsatisfied | `/write-plan` |
+| plan-validate | `solid_reviewed` unsatisfied (after plan_written) | `/arch-review` |
+| implement | `verification_evidence` unsatisfied | `/execute-plan` |
+| review | `pre_pr_review` unsatisfied | `/deep-review` then `/codex-review` |
+| refactor | (manual) when a large refactor is needed | `/refactor-orchestrate` |
+| ship | all session requirements satisfied | finalize commits + PR |
+
+Planning is split because two skills are needed to clear all planning gates: `/write-plan` produces a plan (flips `plan_written`), and `/arch-review` validates it (flips `commit_plan`, `adr_reviewed`, `tdd_planned`, `solid_reviewed`).
+
+## Single entry point
+
+If unsure, just run `/req`. The conductor will derive the phase and dispatch for you.
+
+## Status check
+
+```bash
+req status            # short
+req status --verbose  # full requirement table
+```
+
+## Common transitions
+
+- After `/brainstorm` → `design_approved` flips → next phase: **plan-write**
+- After `/write-plan` → `plan_written` flips → next phase: **plan-validate**
+- After `/arch-review` → 4 planning requirements flip → next phase: **implement**
+- After `/deep-review` → `pre_pr_review` flips → next phase: **ship**
+
+## How to use this index
+
+1. Read the table above and the user's recent prompt.
+2. Identify which requirement is the *next* unsatisfied one along the pipeline.
+3. Recommend (or invoke) the matching command from the table.
+4. If multiple phases look open, default to the earliest one — the pipeline runs top-to-bottom.
+
+This skill is *read-only*: it teaches the map but does not move the project. To act on the map, run `/req` (the conductor command that auto-dispatches) or invoke the matching command directly.

--- a/plugins/requirements-framework/statusline.sh
+++ b/plugins/requirements-framework/statusline.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Phase-aware statusline for Claude Code.
+# Reads Claude's stdin JSON, derives the workflow phase from the
+# requirements-framework state file, and emits a single line.
+#
+# Format:  [phase] [ctx N%] [$cost] [N req⬜]
+# Fail-open: any tool/file failure degrades a single field to `?`,
+# never errors out (Claude Code would hide a non-zero exit script).
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+# Locate the plugin's hook libs.
+# $CLAUDE_PLUGIN_ROOT is set when invoked through Claude Code's plugin loader.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+HOOK_LIB="${PLUGIN_ROOT}/../../../hooks/lib"
+if [[ ! -d "$HOOK_LIB" ]]; then
+  # Deployed layout: ~/.claude/plugins/requirements-framework/statusline.sh
+  # alongside ~/.claude/hooks/lib/
+  HOOK_LIB="${HOME}/.claude/hooks/lib"
+fi
+
+# CWD detection: prefer Claude's reported workspace.
+CWD=$(printf '%s' "$INPUT" | jq -r '.workspace.current_dir // .cwd // "."' 2>/dev/null || echo ".")
+
+# Phase + count default to safe placeholders.
+PHASE="design"
+UNSAT="?"
+
+BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [[ -n "$BRANCH" ]]; then
+  # Mirror branch_to_filename() in hooks/lib/state_storage.py:
+  # slash → dash, then keep [A-Za-z0-9_-] (anything else → underscore).
+  SAFE_BRANCH=$(printf '%s' "$BRANCH" | tr '/\\' '--' | tr -c '[:alnum:]_-' '_')
+  STATE_FILE="$CWD/.git/requirements/${SAFE_BRANCH}.json"
+
+  if [[ -f "$STATE_FILE" ]]; then
+    # One python invocation: prints "<phase> <unsatisfied_count>".
+    # PYTHONPATH lets statusline_data.py import its siblings.
+    read -r PHASE UNSAT < <(
+      PYTHONPATH="$HOOK_LIB" python3 "$HOOK_LIB/statusline_data.py" "$STATE_FILE" 2>/dev/null
+    ) || true
+    [[ -z "${PHASE:-}" ]] && PHASE="design"
+    [[ -z "${UNSAT:-}" ]] && UNSAT="?"
+  fi
+fi
+
+# Context % (input-side, the only one Claude Code currently exposes).
+CTX=$(printf '%s' "$INPUT" | jq -r '.context_window.used_percentage // 0' 2>/dev/null | awk '{printf "%d", $1}')
+[[ -z "$CTX" ]] && CTX="0"
+
+# Session cost in USD.
+COST=$(printf '%s' "$INPUT" | jq -r '.session.cost_usd // 0' 2>/dev/null | awk '{printf "%.2f", $1}')
+[[ -z "$COST" ]] && COST="0.00"
+
+printf "[%s] [ctx %s%%] [\$%s] [%s req⬜]" "$PHASE" "$CTX" "$COST" "$UNSAT"

--- a/sync.sh
+++ b/sync.sh
@@ -118,6 +118,8 @@ get_all_plugin_files() {
         [ -f "$PLUGIN_DEPLOY_DIR/README.md" ] && echo "README.md"
         [ -f "$PLUGIN_REPO_DIR/.mcp.json" ] && echo ".mcp.json"
         [ -f "$PLUGIN_DEPLOY_DIR/.mcp.json" ] && echo ".mcp.json"
+        [ -f "$PLUGIN_REPO_DIR/statusline.sh" ] && echo "statusline.sh"
+        [ -f "$PLUGIN_DEPLOY_DIR/statusline.sh" ] && echo "statusline.sh"
         # Plugin metadata
         [ -f "$PLUGIN_REPO_DIR/.claude-plugin/plugin.json" ] && echo ".claude-plugin/plugin.json"
         [ -f "$PLUGIN_DEPLOY_DIR/.claude-plugin/plugin.json" ] && echo ".claude-plugin/plugin.json"
@@ -378,6 +380,11 @@ deploy_plugin() {
 
     # Copy README
     cp -v "$PLUGIN_REPO_DIR/README.md" "$PLUGIN_DEPLOY_DIR/"
+
+    # Copy statusline. Preserves +x permission via cp -p.
+    if [ -f "$PLUGIN_REPO_DIR/statusline.sh" ]; then
+        cp -pv "$PLUGIN_REPO_DIR/statusline.sh" "$PLUGIN_DEPLOY_DIR/"
+    fi
 
     echo ""
     echo -e "${GREEN}✓ Plugin deployment complete!${NC}"


### PR DESCRIPTION
## Summary

Simplification phase of the requirements-framework refactor — Steps 03–07 from `.claude/plans/simplification/`. Each step lands as one atomic patch in a 5-patch stack. Plugin version moves `3.1.2 → 3.4.2`.

- Adds a phase-aware statusline, a `workflow-index` skill, and a `/req` conductor command — **one entry point** to the workflow regardless of phase.
- Annotates the existing 12 commands with `> Workflow position` header notes mapping each to a `/req` phase.
- Marks 3 overlapping items (`/plan-review`, `/quality-check`, `code-simplifier` agent) as `DEPRECATED`. Removal deferred to a future major release after soak.

## The 5 patches (bottom → top)

| # | Patch | Purpose |
|---|---|---|
| 04 | `feat(skill): add workflow-index for phase→command discovery` | Tiny progressive-disclosure skill mapping phases to commands |
| 03 | `feat(statusline): phase-aware statusline with requirement-derived phase` | One-line statusline + 3 pure-function Python modules + shell script |
| 05 | `feat(command): /req — workflow conductor that dispatches by derived phase` | Markdown command + `scripts/req-phase` wrapper |
| 06 | `feat(commands): add workflow-position header notes to existing commands` | Mechanical edits to 12 command markdown files |
| 07 | `feat(deprecation): mark overlapping commands and agent as deprecated` | Description-only changes; no behavior change |

## Notable design decisions

- **Plan phase is split into `plan-write` → `plan-validate`.** No single skill clears all 5 planning requirements: `/write-plan` flips `plan_written`; `/arch-review` flips the 4 review reqs. The split makes this two-step process visible in the statusline. `/req plan` is a friendly alias.
- **Statusline runtime ~200–300ms** dominated by Python startup; below perceptible-lag threshold.
- **Fail-open posture throughout** — `derive_phase` / `count_unsatisfied` return safe defaults on any error; `statusline_data.main()` has a `try/except Exception` net.

## Deep review

`/deep-review` (11 agents incl. Codex) initially returned **FIX ISSUES FIRST** — 2 CRITICALs in the conductor itself: (1) `/req review` dispatched the wrong skill (`requesting-code-review` → `pre_commit_review`, not `pre_pr_review`) causing an infinite loop; (2) plan-phase gate too thin. Both fixed; the plan-phase fix expanded to the `plan-write`/`plan-validate` split. `/codex-review` re-run on the fixed code verified both CRITICALs resolved.

5 IMPORTANTs also folded into the existing patches: HOOK_LIB dev-mode path, deterministic test-helper filename, branch-mangling alignment with Python canonical, except-clause widening + `isinstance` guards, stripped `(Step 03)` task refs.

## Test plan

- [x] `python3 hooks/test_requirements.py` — 1285/1285 pass
- [x] `./sync.sh deploy` — repo + deployed in sync
- [x] `statusline.sh` end-to-end → `[ship] [ctx 22%] [\$3.10] [2 req⬜]`
- [x] `scripts/req-phase` → `ship`
- [ ] Manual: run `/req` in a fresh session on a framework-using project
- [ ] Soak ~2 weeks before deleting the 3 deprecated items in a follow-up

## Known follow-ups (V3 / Step 08+)

- Guards/dynamic reqs counted as unsatisfied by `count_unsatisfied` (config-aware filtering)
- Worktree state-path should use `--git-common-dir`
- TTL/scope semantics in phase derivation
- Disabled gates lock phase at `design`
- `TypedDict ReqState` in `state_storage.py`
- Single source of truth for phase mapping
- Regression test that parses `req.md`'s dispatch table
- `clear-single-use.py` should clear only on command success — hit during this PR's own creation

## Plugin version

`3.1.2 → 3.4.2`. `git_hash: uncommitted` in two new files will be CI-auto-bumped after merge.
