### PR TITLE
Follow-ups: req verify plugin-aware + CI hardening (tests/ + render check)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "requirements-framework",
-      "version": "4.15.2",
+      "version": "4.15.3",
       "description": "Claude Code Requirements Framework - Workflow enforcement and code review",
       "source": "./plugins/requirements-framework"
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,23 @@ jobs:
 
       - name: Run test suite
         run: python hooks/test_requirements.py
+
+      - name: Check rendered prompts are fresh
+        # Fails if any *.md rendered sibling is stale vs its *.md.j2 source.
+        # jinja2 is already installed above.
+        run: python scripts/render_prompts.py --check
+
+      - name: Run V3 tests/ suite
+        # Script-style suite (each file has its own TestRunner/main(), NOT pytest).
+        # Heavy-dep files (Claude Agent SDK, OTel, etc.) self-skip cleanly when the
+        # optional [llm] extras are absent — only the light extras are installed in
+        # CI. Aggregate exit codes so one failing file fails the job.
+        env:
+          PYTHONDONTWRITEBYTECODE: 1
+        run: |
+          rc=0
+          for f in tests/test_*.py; do
+            echo "== $f =="
+            python "$f" || rc=1
+          done
+          exit $rc

--- a/hooks/requirements-cli.py
+++ b/hooks/requirements-cli.py
@@ -717,169 +717,6 @@ def cmd_prune(args) -> int:
     return 0
 
 
-def _load_settings_file(claude_dir: Path) -> tuple[Path | None, dict]:
-    """Load the first available settings file."""
-
-    for filename in ["settings.json", "settings.local.json"]:
-        path = claude_dir / filename
-        if path.exists():
-            try:
-                content = path.read_text()
-                return path, json.loads(content)
-            except PermissionError:
-                out(f"❌ Cannot read {path}: Permission denied", file=sys.stderr)
-                return path, {}
-            except UnicodeDecodeError as e:
-                out(f"❌ {path} contains invalid UTF-8: {e}", file=sys.stderr)
-                return path, {}
-            except json.JSONDecodeError:
-                out(f"❌ {path} is not valid JSON", file=sys.stderr)
-                return path, {}
-            except (OSError, IOError) as e:
-                out(f"❌ Error reading {path}: {e}", file=sys.stderr)
-                return path, {}
-    return None, {}
-
-
-def _extract_path_from_command(command: str, expected_script: str) -> str | None:
-    """
-    Extract file path from a command string.
-
-    Looks for the expected script name in the command tokens and returns
-    the path containing it. Handles various command formats like:
-    - "python3 ~/.claude/hooks/check-requirements.py"
-    - "~/.claude/hooks/check-requirements.py"
-    - "/usr/bin/python3 /home/user/.claude/hooks/check-requirements.py --flag"
-
-    Args:
-        command: Command string from hook configuration
-        expected_script: Script name to look for (e.g., "check-requirements.py")
-
-    Returns:
-        Extracted path if found, None otherwise
-    """
-    if not isinstance(command, str):
-        return None
-
-    # Split command into tokens
-    tokens = command.split()
-
-    # Find the token containing the expected script
-    for token in tokens:
-        if expected_script in token:
-            # Strip common surrounding characters
-            cleaned = token.strip('";,\'')
-
-            # Verify the cleaned token still contains the script name
-            if expected_script in cleaned:
-                return cleaned
-
-    return None
-
-
-def _check_hook_registration(claude_dir: Path) -> tuple[bool, str]:
-    """Verify PreToolUse hook is registered (new format only)."""
-
-    settings_path, settings = _load_settings_file(claude_dir)
-    expected_script = "check-requirements.py"
-
-    # Safely expand path
-    try:
-        expected_path = str((claude_dir / "hooks" / expected_script).expanduser())
-    except (RuntimeError, OSError) as e:
-        return False, f"Failed to expand path for {expected_script}: {e}"
-
-    if not settings_path:
-        return False, "Missing ~/.claude/settings.json"
-
-    hooks = settings.get("hooks", {})
-    hook_value = hooks.get("PreToolUse")
-
-    if not hook_value:
-        return False, f"PreToolUse hook not registered in {settings_path}"
-
-    # Detect old format (string) and show migration message
-    if isinstance(hook_value, str):
-        return False, (
-            f"PreToolUse hook uses old format (string path).\n"
-            f"Please upgrade to new format in {settings_path}.\n"
-            f"See: https://github.com/anthropics/claude-code/releases"
-        )
-
-    # Check if new format (list)
-    if not isinstance(hook_value, list):
-        actual_type = type(hook_value).__name__
-        return False, (
-            f"PreToolUse hook has unexpected format in {settings_path}\n"
-            f"Expected: list of matchers, Found: {actual_type}"
-        )
-
-    # Track validation issues for better diagnostics
-    malformed_matchers = 0
-    malformed_hooks = 0
-
-    # Iterate through matchers to find our hook
-    for matcher_obj in hook_value:
-        if not isinstance(matcher_obj, dict):
-            malformed_matchers += 1
-            continue
-
-        hooks_list = matcher_obj.get("hooks", [])
-
-        # Validate hooks is a list
-        if not isinstance(hooks_list, list):
-            malformed_hooks += 1
-            continue
-
-        for hook_obj in hooks_list:
-            if not isinstance(hook_obj, dict):
-                malformed_hooks += 1
-                continue
-
-            command = hook_obj.get("command", "")
-            found_path = _extract_path_from_command(command, expected_script)
-
-            if found_path:
-                # Normalize and compare - safely handle path expansion
-                try:
-                    normalized = str(Path(found_path).expanduser())
-                except (RuntimeError, OSError) as e:
-                    return False, f"Invalid path in hook configuration '{found_path}': {e}"
-
-                if normalized != expected_path:
-                    return False, f"PreToolUse hook points to {found_path} (expected {expected_path})"
-
-                return True, f"PreToolUse hook registered in {settings_path}"
-
-    # Hook not found - provide diagnostic info
-    diagnostic_msg = f"PreToolUse hook does not reference {expected_script}"
-    if malformed_matchers > 0 or malformed_hooks > 0:
-        diagnostic_msg += f"\nWarning: Found {malformed_matchers} malformed matcher(s) and {malformed_hooks} malformed hook(s) in {settings_path}"
-        diagnostic_msg += "\nExpected format: [{'matcher': '...', 'hooks': [{'type': 'command', 'command': '...'}]}]"
-
-    return False, diagnostic_msg
-
-
-def _check_executable(path: Path) -> tuple[bool, str]:
-    """Check that a script exists and is executable."""
-
-    if not path.exists():
-        return False, f"Missing {path}"
-    if not os.access(path, os.X_OK):
-        return False, f"{path} is not executable"
-    return True, f"{path} is executable"
-
-
-def _check_project_config(project_dir: str) -> tuple[bool, str]:
-    """Ensure project has a requirements config file."""
-
-    config_path = Path(project_dir) / ".claude" / "requirements.yaml"
-    if config_path.exists():
-        return True, f"Found project config at {config_path}"
-
-    return False, "Missing .claude/requirements.yaml in project"
-
-
 def _find_repo_dir(explicit: str | None = None) -> Path | None:
     """Locate the hooks repository directory containing sync.sh."""
 
@@ -907,73 +744,50 @@ def cmd_verify(args) -> int:
     """
     Verify requirements framework installation.
 
-    Runs a comprehensive check of the installation to ensure
-    hooks are properly registered and functioning.
+    Hooks are registered by the self-contained plugin via
+    plugins/requirements-framework/hooks/hooks.json (the single source of
+    truth, referenced through ${CLAUDE_PLUGIN_ROOT}). This command validates
+    that plugin model — it no longer inspects a ~/.claude/hooks deployment or
+    a ~/.claude/settings.json hooks block (the defunct two-location model).
 
     Returns:
         0 if verification passed, 1 if issues found
     """
+    ci_mode = getattr(args, 'ci', False)
+    repo_dir = _find_repo_dir(getattr(args, 'repo', None))
+
     out(header("🧪 Verifying Requirements Framework Installation"))
     out()
 
     issues_found = False
 
-    # Test 1: Check hook files exist
-    out(info("1. Checking hook files..."))
-    hook_files = [
-        "check-requirements.py",
-        "handle-session-start.py",
-        "handle-stop.py",
-        "handle-session-end.py",
-        "requirements-cli.py"
-    ]
-
-    claude_dir = Path.home() / '.claude'
-    hooks_dir = claude_dir / 'hooks'
-    missing_files = []
-    for hook_file in hook_files:
-        hook_path = hooks_dir / hook_file
-        if not hook_path.exists():
-            missing_files.append(hook_file)
-            out(error(f"  ❌ Missing: {hook_file}"))
+    # Test 1: Plugin-owned hooks.json + every script it registers.
+    out(info("1. Checking plugin-owned hooks..."))
+    for check in _check_plugin_hooks(repo_dir):
+        if check['status'] == 'pass':
+            out(success(f"  ✅ {check['message']}"))
+        elif check['severity'] == 'critical':
+            out(error(f"  ❌ {check['message']}"))
+            if check.get('fix'):
+                out(dim(f"     Fix: {check['fix']['description']}"))
             issues_found = True
-        elif not os.access(hook_path, os.X_OK):
-            out(warning(f"  ⚠️  Not executable: {hook_file}"))
-            out(dim(f"     Fix: chmod +x ~/.claude/hooks/{hook_file}"))
-            issues_found = True
+        else:
+            out(warning(f"  ⚠️  {check['message']}"))
+            if check.get('fix'):
+                out(dim(f"     Fix: {check['fix']['description']}"))
 
-    if not missing_files:
-        out(success("  ✅ All hook files present and executable"))
-
-    # Test 2: Check hook registration
+    # Test 2: Smoke-test the registered PreToolUse hook script.
     out()
-    out(info("2. Checking hook registration..."))
-    settings_path, settings = _load_settings_file(claude_dir)
+    out(info("2. Testing PreToolUse hook response..."))
+    hook_path = None
+    if repo_dir is not None:
+        candidate = (
+            repo_dir / "plugins" / "requirements-framework" / "hooks" / "check-requirements.py"
+        )
+        if candidate.exists():
+            hook_path = candidate
 
-    if not settings_path:
-        out(error("  ❌ settings.json not found"))
-        out(dim("     Run: ./install.sh to register hooks"))
-        issues_found = True
-    else:
-        hooks_config = settings.get('hooks', {})
-        expected_hooks = ['PreToolUse', 'SessionStart', 'Stop', 'SessionEnd']
-        missing_hooks = []
-
-        for hook_type in expected_hooks:
-            if hook_type not in hooks_config:
-                missing_hooks.append(hook_type)
-                out(error(f"  ❌ {hook_type} hook not registered"))
-                issues_found = True
-
-        if not missing_hooks:
-            out(success("  ✅ All hooks registered in settings"))
-
-    # Test 3: Test PreToolUse hook responds
-    out()
-    out(info("3. Testing PreToolUse hook response..."))
-    hook_path = hooks_dir / "check-requirements.py"
-
-    if hook_path.exists():
+    if hook_path is not None:
         import subprocess
         result = subprocess.run(
             ["python3", str(hook_path)],
@@ -991,35 +805,33 @@ def cmd_verify(args) -> int:
                 out(dim(f"     Error: {result.stderr[:200]}"))
             issues_found = True
     else:
-        out(warning("  ⚠️  Skipped (hook file missing)"))
+        out(warning("  ⚠️  Skipped (plugin check-requirements.py not found)"))
 
-    # Test 4: Check req command accessibility
-    out()
-    out(info("4. Checking 'req' command..."))
-    req_link = Path.home() / '.local' / 'bin' / 'req'
+    # CLI/runtime checks concern the local Claude Code install, not the
+    # framework code — skip them in --ci mode (mirrors `req doctor --ci`).
+    if not ci_mode:
+        import shutil
 
-    if req_link.exists():
-        out(success("  ✅ 'req' command is accessible"))
-    else:
-        out(warning("  ⚠️  'req' symlink not found"))
-        out(dim("     Run: ./install.sh to create symlink"))
+        # Test 3: Check req command accessibility
+        out()
+        out(info("3. Checking 'req' command..."))
+        req_path = shutil.which('req')
+        if req_path:
+            out(success(f"  ✅ 'req' command is accessible ({req_path})"))
+        else:
+            out(warning("  ⚠️  'req' command not found in PATH"))
+            out(dim("     Run: ./install.sh to set up the 'req' CLI"))
 
-    # Check PATH
-    local_bin = str(Path.home() / '.local' / 'bin')
-    if local_bin not in os.environ.get('PATH', ''):
-        out(warning("  ⚠️  ~/.local/bin not in PATH"))
-        out(dim("     Add: export PATH=\"$HOME/.local/bin:$PATH\""))
+        # Test 4: Check config exists
+        out()
+        out(info("4. Checking configuration..."))
+        global_config = Path.home() / '.claude' / 'requirements.yaml'
 
-    # Test 5: Check config exists
-    out()
-    out(info("5. Checking configuration..."))
-    global_config = Path.home() / '.claude' / 'requirements.yaml'
-
-    if global_config.exists():
-        out(success("  ✅ Global config exists"))
-    else:
-        out(warning("  ⚠️  No global config"))
-        out(dim("     Run: ./install.sh to install default config"))
+        if global_config.exists():
+            out(success("  ✅ Global config exists"))
+        else:
+            out(warning("  ⚠️  No global config"))
+            out(dim("     Run: ./install.sh to install default config"))
 
     # Summary
     out()
@@ -1027,10 +839,10 @@ def cmd_verify(args) -> int:
     if issues_found:
         out(error("❌ Verification failed - issues found"))
         out()
-        out(hint("💡 Run './install.sh' to fix installation issues"))
+        out(hint("💡 Run 'req doctor --verbose' for full diagnostics"))
         return 1
     else:
-        out(success("✅ Framework fully functional!"))
+        out(success("✅ Framework hooks validated!"))
         out()
         out(hint("💡 Next: Run 'req init' in your project to set up requirements"))
         return 0
@@ -3782,7 +3594,9 @@ Environment Variables:
                               help='Show which file each setting comes from')
 
     # verify
-    subparsers.add_parser('verify', help='Verify framework installation is working correctly')
+    verify_parser = subparsers.add_parser('verify', help='Verify framework installation is working correctly')
+    verify_parser.add_argument('--repo', help='Path to hooks repository (defaults to auto-detect)')
+    verify_parser.add_argument('--ci', action='store_true', help='CI-friendly mode: only validate plugin hooks, skip local Claude Code config checks')
 
     # doctor
     doctor_parser = subparsers.add_parser('doctor', help='Run comprehensive framework diagnostics')

--- a/hooks/test_requirements.py
+++ b/hooks/test_requirements.py
@@ -9979,6 +9979,34 @@ def test_plugin_hooks_bundle_fresh(runner: TestRunner):
         f"exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}",
     )
 
+    # __pycache__ in the bundle must NOT count as drift — it is gitignored
+    # bytecode regenerated at runtime (e.g. `req verify` smoke-testing the
+    # plugin's check-requirements.py, or the suite itself). Regression guard for
+    # the CI false-failure where build --check flagged
+    # plugins/.../hooks/lib/__pycache__ as drift (exit 1).
+    bundle_cache = repo_root / 'plugins' / 'requirements-framework' / 'hooks' / 'lib' / '__pycache__'
+    created_cache = not bundle_cache.exists()
+    bundle_cache.mkdir(parents=True, exist_ok=True)
+    sentinel = bundle_cache / '_drift_guard_test.pyc'
+    sentinel.write_bytes(b'\x00')
+    try:
+        result_cache = subprocess.run(
+            [sys.executable, str(build_script), '--check'],
+            cwd=str(repo_root), capture_output=True, text=True,
+        )
+        runner.test(
+            "build --check ignores __pycache__ in the bundle (not drift)",
+            result_cache.returncode == 0,
+            f"exit={result_cache.returncode}\nstdout={result_cache.stdout}",
+        )
+    finally:
+        sentinel.unlink(missing_ok=True)
+        if created_cache:
+            try:
+                bundle_cache.rmdir()
+            except OSError:
+                pass
+
 
 def test_plugin_hooks_json_self_contained(runner: TestRunner):
     """hooks.json is plugin-root-relative, not deploy-path-bound.

--- a/hooks/test_requirements.py
+++ b/hooks/test_requirements.py
@@ -1716,6 +1716,85 @@ def test_cli_doctor_command(runner: TestRunner):
         runner.test("Shows all checks", "All Checks" in result.stdout, result.stdout)
 
 
+def test_cli_verify_command(runner: TestRunner):
+    """`req verify` validates the plugin-owned hook model, not a ~/.claude deploy.
+
+    Hooks are registered by plugins/requirements-framework/hooks/hooks.json (the
+    single source of truth via ${CLAUDE_PLUGIN_ROOT}). verify therefore reuses
+    the same plugin-hook integrity checks as doctor and no longer inspects a
+    ~/.claude/hooks deployment or a ~/.claude/settings.json hooks block.
+    """
+
+    print("\n📦 Testing verify command...")
+
+    cli_path = Path(__file__).parent / "requirements-cli.py"
+    repo_root = Path(__file__).parent.parent
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Isolated HOME so verify does not read the developer's real ~/.claude.
+        # With no ~/.claude config present, the CLI/config checks are warnings
+        # (not failures), so verify must still exit 0 against a clean repo.
+        home_dir = Path(tmpdir)
+        env = {**os.environ, "HOME": str(home_dir)}
+
+        result = subprocess.run(
+            ["python3", str(cli_path), "verify", "--repo", str(repo_root)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        runner.test("verify runs and exits 0", result.returncode == 0, result.stdout + result.stderr)
+        runner.test(
+            "verify validates plugin hooks.json",
+            "hooks.json present and valid" in result.stdout,
+            result.stdout,
+        )
+        runner.test(
+            "verify reports plugin hook scripts",
+            "check-requirements.py exists" in result.stdout,
+            result.stdout,
+        )
+        runner.test(
+            "verify no longer checks ~/.claude/settings.json registration",
+            "hook not registered" not in result.stdout,
+            result.stdout,
+        )
+
+        # --ci mode skips the local CLI/config checks (mirrors doctor --ci).
+        result_ci = subprocess.run(
+            ["python3", str(cli_path), "verify", "--ci", "--repo", str(repo_root)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        runner.test("verify --ci exits 0", result_ci.returncode == 0, result_ci.stdout + result_ci.stderr)
+        runner.test(
+            "verify --ci skips 'req' command check",
+            "Checking 'req' command" not in result_ci.stdout,
+            result_ci.stdout,
+        )
+
+    # Against a temp repo missing hooks.json, verify reports a critical failure
+    # and exits 1.
+    with tempfile.TemporaryDirectory() as tmpdir2:
+        broken_repo = Path(tmpdir2)
+        (broken_repo / "sync.sh").write_text("#!/bin/sh\n")
+        (broken_repo / "plugins" / "requirements-framework" / "hooks").mkdir(parents=True)
+        env2 = {**os.environ, "HOME": str(broken_repo)}
+
+        result_fail = subprocess.run(
+            ["python3", str(cli_path), "verify", "--repo", str(broken_repo)],
+            capture_output=True,
+            text=True,
+            env=env2,
+        )
+        runner.test(
+            "verify fails (exit 1) when plugin hooks.json is missing",
+            result_fail.returncode == 1,
+            result_fail.stdout + result_fail.stderr,
+        )
+
+
 def test_enhanced_doctor_json_output(runner: TestRunner):
     """Test enhanced doctor JSON output mode."""
     print("\n📦 Testing enhanced doctor --json...")
@@ -12608,6 +12687,7 @@ def main():
     test_cli_status_modes(runner)
     test_cli_sessions_command(runner)
     test_cli_doctor_command(runner)
+    test_cli_verify_command(runner)
     test_enhanced_doctor_json_output(runner)
     test_enhanced_doctor_check_functions(runner)
     test_doctor_plugin_hooks_checks(runner)

--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "4.15.2",
+  "version": "4.15.3",
   "description": "Claude Code Requirements Framework - Complete development lifecycle from ideation to completion. Enforces workflow requirements through hooks, guides process with 21 development skills (brainstorming, TDD, debugging, verification), and provides comprehensive code review agents.",
   "author": {
     "name": "Harm"

--- a/plugins/requirements-framework/hooks/requirements-cli.py
+++ b/plugins/requirements-framework/hooks/requirements-cli.py
@@ -717,169 +717,6 @@ def cmd_prune(args) -> int:
     return 0
 
 
-def _load_settings_file(claude_dir: Path) -> tuple[Path | None, dict]:
-    """Load the first available settings file."""
-
-    for filename in ["settings.json", "settings.local.json"]:
-        path = claude_dir / filename
-        if path.exists():
-            try:
-                content = path.read_text()
-                return path, json.loads(content)
-            except PermissionError:
-                out(f"❌ Cannot read {path}: Permission denied", file=sys.stderr)
-                return path, {}
-            except UnicodeDecodeError as e:
-                out(f"❌ {path} contains invalid UTF-8: {e}", file=sys.stderr)
-                return path, {}
-            except json.JSONDecodeError:
-                out(f"❌ {path} is not valid JSON", file=sys.stderr)
-                return path, {}
-            except (OSError, IOError) as e:
-                out(f"❌ Error reading {path}: {e}", file=sys.stderr)
-                return path, {}
-    return None, {}
-
-
-def _extract_path_from_command(command: str, expected_script: str) -> str | None:
-    """
-    Extract file path from a command string.
-
-    Looks for the expected script name in the command tokens and returns
-    the path containing it. Handles various command formats like:
-    - "python3 ~/.claude/hooks/check-requirements.py"
-    - "~/.claude/hooks/check-requirements.py"
-    - "/usr/bin/python3 /home/user/.claude/hooks/check-requirements.py --flag"
-
-    Args:
-        command: Command string from hook configuration
-        expected_script: Script name to look for (e.g., "check-requirements.py")
-
-    Returns:
-        Extracted path if found, None otherwise
-    """
-    if not isinstance(command, str):
-        return None
-
-    # Split command into tokens
-    tokens = command.split()
-
-    # Find the token containing the expected script
-    for token in tokens:
-        if expected_script in token:
-            # Strip common surrounding characters
-            cleaned = token.strip('";,\'')
-
-            # Verify the cleaned token still contains the script name
-            if expected_script in cleaned:
-                return cleaned
-
-    return None
-
-
-def _check_hook_registration(claude_dir: Path) -> tuple[bool, str]:
-    """Verify PreToolUse hook is registered (new format only)."""
-
-    settings_path, settings = _load_settings_file(claude_dir)
-    expected_script = "check-requirements.py"
-
-    # Safely expand path
-    try:
-        expected_path = str((claude_dir / "hooks" / expected_script).expanduser())
-    except (RuntimeError, OSError) as e:
-        return False, f"Failed to expand path for {expected_script}: {e}"
-
-    if not settings_path:
-        return False, "Missing ~/.claude/settings.json"
-
-    hooks = settings.get("hooks", {})
-    hook_value = hooks.get("PreToolUse")
-
-    if not hook_value:
-        return False, f"PreToolUse hook not registered in {settings_path}"
-
-    # Detect old format (string) and show migration message
-    if isinstance(hook_value, str):
-        return False, (
-            f"PreToolUse hook uses old format (string path).\n"
-            f"Please upgrade to new format in {settings_path}.\n"
-            f"See: https://github.com/anthropics/claude-code/releases"
-        )
-
-    # Check if new format (list)
-    if not isinstance(hook_value, list):
-        actual_type = type(hook_value).__name__
-        return False, (
-            f"PreToolUse hook has unexpected format in {settings_path}\n"
-            f"Expected: list of matchers, Found: {actual_type}"
-        )
-
-    # Track validation issues for better diagnostics
-    malformed_matchers = 0
-    malformed_hooks = 0
-
-    # Iterate through matchers to find our hook
-    for matcher_obj in hook_value:
-        if not isinstance(matcher_obj, dict):
-            malformed_matchers += 1
-            continue
-
-        hooks_list = matcher_obj.get("hooks", [])
-
-        # Validate hooks is a list
-        if not isinstance(hooks_list, list):
-            malformed_hooks += 1
-            continue
-
-        for hook_obj in hooks_list:
-            if not isinstance(hook_obj, dict):
-                malformed_hooks += 1
-                continue
-
-            command = hook_obj.get("command", "")
-            found_path = _extract_path_from_command(command, expected_script)
-
-            if found_path:
-                # Normalize and compare - safely handle path expansion
-                try:
-                    normalized = str(Path(found_path).expanduser())
-                except (RuntimeError, OSError) as e:
-                    return False, f"Invalid path in hook configuration '{found_path}': {e}"
-
-                if normalized != expected_path:
-                    return False, f"PreToolUse hook points to {found_path} (expected {expected_path})"
-
-                return True, f"PreToolUse hook registered in {settings_path}"
-
-    # Hook not found - provide diagnostic info
-    diagnostic_msg = f"PreToolUse hook does not reference {expected_script}"
-    if malformed_matchers > 0 or malformed_hooks > 0:
-        diagnostic_msg += f"\nWarning: Found {malformed_matchers} malformed matcher(s) and {malformed_hooks} malformed hook(s) in {settings_path}"
-        diagnostic_msg += "\nExpected format: [{'matcher': '...', 'hooks': [{'type': 'command', 'command': '...'}]}]"
-
-    return False, diagnostic_msg
-
-
-def _check_executable(path: Path) -> tuple[bool, str]:
-    """Check that a script exists and is executable."""
-
-    if not path.exists():
-        return False, f"Missing {path}"
-    if not os.access(path, os.X_OK):
-        return False, f"{path} is not executable"
-    return True, f"{path} is executable"
-
-
-def _check_project_config(project_dir: str) -> tuple[bool, str]:
-    """Ensure project has a requirements config file."""
-
-    config_path = Path(project_dir) / ".claude" / "requirements.yaml"
-    if config_path.exists():
-        return True, f"Found project config at {config_path}"
-
-    return False, "Missing .claude/requirements.yaml in project"
-
-
 def _find_repo_dir(explicit: str | None = None) -> Path | None:
     """Locate the hooks repository directory containing sync.sh."""
 
@@ -907,73 +744,50 @@ def cmd_verify(args) -> int:
     """
     Verify requirements framework installation.
 
-    Runs a comprehensive check of the installation to ensure
-    hooks are properly registered and functioning.
+    Hooks are registered by the self-contained plugin via
+    plugins/requirements-framework/hooks/hooks.json (the single source of
+    truth, referenced through ${CLAUDE_PLUGIN_ROOT}). This command validates
+    that plugin model — it no longer inspects a ~/.claude/hooks deployment or
+    a ~/.claude/settings.json hooks block (the defunct two-location model).
 
     Returns:
         0 if verification passed, 1 if issues found
     """
+    ci_mode = getattr(args, 'ci', False)
+    repo_dir = _find_repo_dir(getattr(args, 'repo', None))
+
     out(header("🧪 Verifying Requirements Framework Installation"))
     out()
 
     issues_found = False
 
-    # Test 1: Check hook files exist
-    out(info("1. Checking hook files..."))
-    hook_files = [
-        "check-requirements.py",
-        "handle-session-start.py",
-        "handle-stop.py",
-        "handle-session-end.py",
-        "requirements-cli.py"
-    ]
-
-    claude_dir = Path.home() / '.claude'
-    hooks_dir = claude_dir / 'hooks'
-    missing_files = []
-    for hook_file in hook_files:
-        hook_path = hooks_dir / hook_file
-        if not hook_path.exists():
-            missing_files.append(hook_file)
-            out(error(f"  ❌ Missing: {hook_file}"))
+    # Test 1: Plugin-owned hooks.json + every script it registers.
+    out(info("1. Checking plugin-owned hooks..."))
+    for check in _check_plugin_hooks(repo_dir):
+        if check['status'] == 'pass':
+            out(success(f"  ✅ {check['message']}"))
+        elif check['severity'] == 'critical':
+            out(error(f"  ❌ {check['message']}"))
+            if check.get('fix'):
+                out(dim(f"     Fix: {check['fix']['description']}"))
             issues_found = True
-        elif not os.access(hook_path, os.X_OK):
-            out(warning(f"  ⚠️  Not executable: {hook_file}"))
-            out(dim(f"     Fix: chmod +x ~/.claude/hooks/{hook_file}"))
-            issues_found = True
+        else:
+            out(warning(f"  ⚠️  {check['message']}"))
+            if check.get('fix'):
+                out(dim(f"     Fix: {check['fix']['description']}"))
 
-    if not missing_files:
-        out(success("  ✅ All hook files present and executable"))
-
-    # Test 2: Check hook registration
+    # Test 2: Smoke-test the registered PreToolUse hook script.
     out()
-    out(info("2. Checking hook registration..."))
-    settings_path, settings = _load_settings_file(claude_dir)
+    out(info("2. Testing PreToolUse hook response..."))
+    hook_path = None
+    if repo_dir is not None:
+        candidate = (
+            repo_dir / "plugins" / "requirements-framework" / "hooks" / "check-requirements.py"
+        )
+        if candidate.exists():
+            hook_path = candidate
 
-    if not settings_path:
-        out(error("  ❌ settings.json not found"))
-        out(dim("     Run: ./install.sh to register hooks"))
-        issues_found = True
-    else:
-        hooks_config = settings.get('hooks', {})
-        expected_hooks = ['PreToolUse', 'SessionStart', 'Stop', 'SessionEnd']
-        missing_hooks = []
-
-        for hook_type in expected_hooks:
-            if hook_type not in hooks_config:
-                missing_hooks.append(hook_type)
-                out(error(f"  ❌ {hook_type} hook not registered"))
-                issues_found = True
-
-        if not missing_hooks:
-            out(success("  ✅ All hooks registered in settings"))
-
-    # Test 3: Test PreToolUse hook responds
-    out()
-    out(info("3. Testing PreToolUse hook response..."))
-    hook_path = hooks_dir / "check-requirements.py"
-
-    if hook_path.exists():
+    if hook_path is not None:
         import subprocess
         result = subprocess.run(
             ["python3", str(hook_path)],
@@ -991,35 +805,33 @@ def cmd_verify(args) -> int:
                 out(dim(f"     Error: {result.stderr[:200]}"))
             issues_found = True
     else:
-        out(warning("  ⚠️  Skipped (hook file missing)"))
+        out(warning("  ⚠️  Skipped (plugin check-requirements.py not found)"))
 
-    # Test 4: Check req command accessibility
-    out()
-    out(info("4. Checking 'req' command..."))
-    req_link = Path.home() / '.local' / 'bin' / 'req'
+    # CLI/runtime checks concern the local Claude Code install, not the
+    # framework code — skip them in --ci mode (mirrors `req doctor --ci`).
+    if not ci_mode:
+        import shutil
 
-    if req_link.exists():
-        out(success("  ✅ 'req' command is accessible"))
-    else:
-        out(warning("  ⚠️  'req' symlink not found"))
-        out(dim("     Run: ./install.sh to create symlink"))
+        # Test 3: Check req command accessibility
+        out()
+        out(info("3. Checking 'req' command..."))
+        req_path = shutil.which('req')
+        if req_path:
+            out(success(f"  ✅ 'req' command is accessible ({req_path})"))
+        else:
+            out(warning("  ⚠️  'req' command not found in PATH"))
+            out(dim("     Run: ./install.sh to set up the 'req' CLI"))
 
-    # Check PATH
-    local_bin = str(Path.home() / '.local' / 'bin')
-    if local_bin not in os.environ.get('PATH', ''):
-        out(warning("  ⚠️  ~/.local/bin not in PATH"))
-        out(dim("     Add: export PATH=\"$HOME/.local/bin:$PATH\""))
+        # Test 4: Check config exists
+        out()
+        out(info("4. Checking configuration..."))
+        global_config = Path.home() / '.claude' / 'requirements.yaml'
 
-    # Test 5: Check config exists
-    out()
-    out(info("5. Checking configuration..."))
-    global_config = Path.home() / '.claude' / 'requirements.yaml'
-
-    if global_config.exists():
-        out(success("  ✅ Global config exists"))
-    else:
-        out(warning("  ⚠️  No global config"))
-        out(dim("     Run: ./install.sh to install default config"))
+        if global_config.exists():
+            out(success("  ✅ Global config exists"))
+        else:
+            out(warning("  ⚠️  No global config"))
+            out(dim("     Run: ./install.sh to install default config"))
 
     # Summary
     out()
@@ -1027,10 +839,10 @@ def cmd_verify(args) -> int:
     if issues_found:
         out(error("❌ Verification failed - issues found"))
         out()
-        out(hint("💡 Run './install.sh' to fix installation issues"))
+        out(hint("💡 Run 'req doctor --verbose' for full diagnostics"))
         return 1
     else:
-        out(success("✅ Framework fully functional!"))
+        out(success("✅ Framework hooks validated!"))
         out()
         out(hint("💡 Next: Run 'req init' in your project to set up requirements"))
         return 0
@@ -3782,7 +3594,9 @@ Environment Variables:
                               help='Show which file each setting comes from')
 
     # verify
-    subparsers.add_parser('verify', help='Verify framework installation is working correctly')
+    verify_parser = subparsers.add_parser('verify', help='Verify framework installation is working correctly')
+    verify_parser.add_argument('--repo', help='Path to hooks repository (defaults to auto-detect)')
+    verify_parser.add_argument('--ci', action='store_true', help='CI-friendly mode: only validate plugin hooks, skip local Claude Code config checks')
 
     # doctor
     doctor_parser = subparsers.add_parser('doctor', help='Run comprehensive framework diagnostics')

--- a/scripts/build_plugin_hooks.py
+++ b/scripts/build_plugin_hooks.py
@@ -180,9 +180,14 @@ def check() -> int:
             continue
         if dest_py not in expected:
             extra.append(dest_py)
-    stale_cache = _dest_pycache_dirs()
 
-    if not (missing or differing or extra or stale_cache):
+    # __pycache__/*.pyc in the bundle is NOT drift: it is gitignored bytecode
+    # regenerated at runtime whenever anything imports from the bundle tree
+    # (e.g. `req verify` smoke-testing the plugin's check-requirements.py, or the
+    # test suite itself). Flagging it caused false CI failures. Source integrity
+    # is purely about .py CONTENT (missing / content-differs / stale-extra);
+    # `build()` still prunes __pycache__ as housekeeping.
+    if not (missing or differing or extra):
         print(f"Bundle in sync: {len(expected)} file(s) match source.")
         return 0
 
@@ -191,7 +196,6 @@ def check() -> int:
         ("missing", missing),
         ("content-differs", differing),
         ("stale-extra", extra),
-        ("__pycache__", stale_cache),
     ):
         for item in sorted(items):
             print(f"  [{label}] {item.relative_to(REPO_ROOT)}")

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -17,6 +17,16 @@ from unittest.mock import patch
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Optional heavy dep: the V3 worker / claude-wrapper modules this suite exercises
+# eager-import the Claude Agent SDK. CI installs only the light llm extras
+# (pyyaml/pydantic/jinja2), so skip cleanly instead of crashing when the SDK is
+# absent — mirrors the optional-dep skip pattern in hooks/test_requirements.py.
+try:
+    import claude_agent_sdk  # noqa: F401
+except ModuleNotFoundError as e:
+    print(f"   ⊘ skipped: optional dep absent ({e.name})")
+    sys.exit(0)
+
 
 class TestRunner:
     def __init__(self):

--- a/tests/test_claude_wrapper.py
+++ b/tests/test_claude_wrapper.py
@@ -16,6 +16,16 @@ from unittest.mock import patch
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Optional heavy dep: the V3 worker / claude-wrapper modules this suite exercises
+# eager-import the Claude Agent SDK. CI installs only the light llm extras
+# (pyyaml/pydantic/jinja2), so skip cleanly instead of crashing when the SDK is
+# absent — mirrors the optional-dep skip pattern in hooks/test_requirements.py.
+try:
+    import claude_agent_sdk  # noqa: F401
+except ModuleNotFoundError as e:
+    print(f"   ⊘ skipped: optional dep absent ({e.name})")
+    sys.exit(0)
+
 
 class TestRunner:
     def __init__(self):

--- a/tests/test_code_reviewer_worker.py
+++ b/tests/test_code_reviewer_worker.py
@@ -17,6 +17,16 @@ from unittest.mock import patch
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Optional heavy dep: the V3 worker / claude-wrapper modules this suite exercises
+# eager-import the Claude Agent SDK. CI installs only the light llm extras
+# (pyyaml/pydantic/jinja2), so skip cleanly instead of crashing when the SDK is
+# absent — mirrors the optional-dep skip pattern in hooks/test_requirements.py.
+try:
+    import claude_agent_sdk  # noqa: F401
+except ModuleNotFoundError as e:
+    print(f"   ⊘ skipped: optional dep absent ({e.name})")
+    sys.exit(0)
+
 
 class TestRunner:
     def __init__(self):

--- a/tests/test_fanout.py
+++ b/tests/test_fanout.py
@@ -18,6 +18,16 @@ from unittest.mock import patch
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Optional heavy dep: the V3 worker / claude-wrapper modules this suite exercises
+# eager-import the Claude Agent SDK. CI installs only the light llm extras
+# (pyyaml/pydantic/jinja2), so skip cleanly instead of crashing when the SDK is
+# absent — mirrors the optional-dep skip pattern in hooks/test_requirements.py.
+try:
+    import claude_agent_sdk  # noqa: F401
+except ModuleNotFoundError as e:
+    print(f"   ⊘ skipped: optional dep absent ({e.name})")
+    sys.exit(0)
+
 from hooks.lib.llm.schemas import ReviewReport
 from hooks.lib.llm.workers import fanout
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -213,6 +213,16 @@ def test_module_import_triggers_init(runner: TestRunner):
 
 def test_logs_init_failure_with_traceback_only_when_debug_set(runner: TestRunner):
     print("\ntest_logs_init_failure_with_traceback_only_when_debug_set")
+    # This test forces a failure AFTER the OTel provider is built, so it needs
+    # the real opentelemetry stack present; absent it, init_observability() bails
+    # earlier on the missing-dep ImportError branch and never reaches the
+    # traceback path under test. CI installs only the light llm extras, so skip
+    # this one case cleanly (the other tests here are genuinely dep-free).
+    try:
+        import opentelemetry  # noqa: F401
+    except ModuleNotFoundError as e:
+        print(f"   ⊘ skipped: optional dep absent ({e.name})")
+        return
     fake_env = {
         "LANGFUSE_PUBLIC_KEY": "pk-test",
         "LANGFUSE_SECRET_KEY": "sk-test",

--- a/tests/test_review_cli.py
+++ b/tests/test_review_cli.py
@@ -16,6 +16,16 @@ from unittest.mock import patch
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Optional heavy dep: the V3 worker / claude-wrapper modules this suite exercises
+# eager-import the Claude Agent SDK. CI installs only the light llm extras
+# (pyyaml/pydantic/jinja2), so skip cleanly instead of crashing when the SDK is
+# absent — mirrors the optional-dep skip pattern in hooks/test_requirements.py.
+try:
+    import claude_agent_sdk  # noqa: F401
+except ModuleNotFoundError as e:
+    print(f"   ⊘ skipped: optional dep absent ({e.name})")
+    sys.exit(0)
+
 from hooks.lib.llm import review_cli
 from hooks.lib.llm.schemas import ReviewReport
 from hooks.lib.llm.workers.fanout import FanoutResult

--- a/tests/test_review_roster.py
+++ b/tests/test_review_roster.py
@@ -16,6 +16,16 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Optional heavy dep: the V3 worker / claude-wrapper modules this suite exercises
+# eager-import the Claude Agent SDK. CI installs only the light llm extras
+# (pyyaml/pydantic/jinja2), so skip cleanly instead of crashing when the SDK is
+# absent — mirrors the optional-dep skip pattern in hooks/test_requirements.py.
+try:
+    import claude_agent_sdk  # noqa: F401
+except ModuleNotFoundError as e:
+    print(f"   ⊘ skipped: optional dep absent ({e.name})")
+    sys.exit(0)
+
 from hooks.lib.llm.workers.rosters import review_workers
 
 

--- a/tests/test_review_workers.py
+++ b/tests/test_review_workers.py
@@ -18,6 +18,16 @@ from unittest.mock import patch
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Optional heavy dep: the V3 worker / claude-wrapper modules this suite exercises
+# eager-import the Claude Agent SDK. CI installs only the light llm extras
+# (pyyaml/pydantic/jinja2), so skip cleanly instead of crashing when the SDK is
+# absent — mirrors the optional-dep skip pattern in hooks/test_requirements.py.
+try:
+    import claude_agent_sdk  # noqa: F401
+except ModuleNotFoundError as e:
+    print(f"   ⊘ skipped: optional dep absent ({e.name})")
+    sys.exit(0)
+
 
 class TestRunner:
     def __init__(self):

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -24,6 +24,16 @@ from unittest.mock import patch
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Optional heavy dep: the V3 worker / claude-wrapper modules this suite exercises
+# eager-import the Claude Agent SDK. CI installs only the light llm extras
+# (pyyaml/pydantic/jinja2), so skip cleanly instead of crashing when the SDK is
+# absent — mirrors the optional-dep skip pattern in hooks/test_requirements.py.
+try:
+    import claude_agent_sdk  # noqa: F401
+except ModuleNotFoundError as e:
+    print(f"   ⊘ skipped: optional dep absent ({e.name})")
+    sys.exit(0)
+
 
 class TestRunner:
     def __init__(self):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -20,6 +20,16 @@ from unittest.mock import patch
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Optional heavy dep: the supervisor patches the claude-wrapper (hooks.lib.llm.claude),
+# which eager-imports the Claude Agent SDK. CI installs only the light llm extras
+# (pyyaml/pydantic/jinja2), so skip cleanly instead of crashing when the SDK is
+# absent — mirrors the optional-dep skip pattern in hooks/test_requirements.py.
+try:
+    import claude_agent_sdk  # noqa: F401
+except ModuleNotFoundError as e:
+    print(f"   ⊘ skipped: optional dep absent ({e.name})")
+    sys.exit(0)
+
 
 class TestRunner:
     def __init__(self):


### PR DESCRIPTION
## What

Two post-merge follow-ups (deferred non-blocking from the Phase-3 merge plan).

### `req verify` plugin-aware (`step-6-req-verify-plugin-aware`)
The last command still asserting the defunct two-location deploy (`~/.claude/hooks` files + `~/.claude/settings.json` registration + deployed-hook dry-run) — it returned exit 1 on any undeployed checkout. Now mirrors the `req doctor` fix: reuses `_check_plugin_hooks()` to validate the plugin `hooks.json` + its `${CLAUDE_PLUGIN_ROOT}` scripts; adds `--repo`/`--ci`; removes the dead two-location helpers. Plugin 4.15.2 → 4.15.3.

### CI hardening (`step-6-ci-harden-tests-render`)
CI ran only `doctor` + the main suite; the 23-file `tests/` V3 suite was **CI-invisible** and rotted unnoticed (the orphaned `test_supervisor`/`test_schemas` proved it). Now:
- Each heavy-dep `tests/` file **self-skips** when its optional `[llm]` dep is absent (9 guard `claude_agent_sdk`, 1 OTel) — a real bug still surfaces when the dep is present.
- `ci.yml` gains two steps: `render_prompts.py --check` (template freshness) + a loop running every `tests/` file (fails on any real failure, skips OK).

## Verified
- main suite **1460/1460** · bundle in sync · render `--check` fresh · `doctor --ci` + `verify --ci` exit 0
- `tests/` — full-deps **23/23**; CI light-deps **rc=0 (13 run / 10 skip)**
