### PR TITLE
ci: bump checkout/setup-python to v6 (Node-24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout with full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
Bumps `actions/checkout@v4→v6` and `actions/setup-python@v5→v6` (latest, Node-24-native) in ci.yml + publish.yml, clearing the Node-20 deprecation ahead of GitHub's 2026-06-16 forced cutover. Workflow-only; this CI run validates the new action versions.