### PR TITLE
Clean ruff debt correctly + add ruff gate to CI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "requirements-framework",
-      "version": "4.15.4",
+      "version": "4.15.5",
       "description": "Claude Code Requirements Framework - Workflow enforcement and code review",
       "source": "./plugins/requirements-framework"
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,14 @@ jobs:
         # [llm] extra that the in-suite V3 tests (e.g. test_supervisor_config_driven)
         # import directly — NOT the full extra (which drags torch/sentence-transformers/
         # ragas). Without these the suite ModuleNotFound-crashes on a clean runner.
-        run: pip install pyyaml pydantic jinja2
+        # ruff is PINNED so a future release can't flag new rules on unchanged code.
+        run: pip install pyyaml pydantic jinja2 ruff==0.12.12
+
+      - name: Lint (ruff)
+        # The missing merge gate: lint debt used to accumulate silently because only
+        # the opt-in /v3-review tool gate ran ruff. The generated plugin bundle is
+        # excluded in ruff.toml (byte-identical mirror; build --check enforces equality).
+        run: ruff check .
 
       - name: Prepare Claude home
         run: |

--- a/hooks/lib/blocking_strategy.py
+++ b/hooks/lib/blocking_strategy.py
@@ -10,7 +10,7 @@ These requirements must be manually satisfied via the CLI using
 Examples: commit_plan, adr_reviewed, github_ticket
 """
 
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 # Import from sibling modules
 try:
@@ -22,9 +22,6 @@ except ImportError as e:
     # For testing, allow imports to fail gracefully but log warning
     import sys
     sys.stderr.write(f"[WARNING] blocking_strategy import failed: {e}\n")
-
-if TYPE_CHECKING:
-    from messages import MessageLoader
 
 
 class BlockingRequirementStrategy(RequirementStrategy):

--- a/hooks/lib/feature_selector.py
+++ b/hooks/lib/feature_selector.py
@@ -12,7 +12,6 @@ Usage:
     config = selector.build_config_from_features(selected, context='project')
 """
 from typing import Dict, List, Any
-from pathlib import Path
 
 
 # Feature catalog - maps requirement keys to user-friendly descriptions

--- a/hooks/lib/guard_strategy.py
+++ b/hooks/lib/guard_strategy.py
@@ -13,7 +13,7 @@ Guards are different from blocking/dynamic requirements:
 Examples: protected_branch (prevents edits on main/master)
 """
 
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 # Import from sibling modules
 try:
@@ -25,9 +25,6 @@ except ImportError as e:
     # For testing, allow imports to fail gracefully but log warning
     import sys
     sys.stderr.write(f"[WARNING] guard_strategy import failed: {e}\n")
-
-if TYPE_CHECKING:
-    from messages import MessageLoader
 
 
 class GuardRequirementStrategy(RequirementStrategy):

--- a/hooks/lib/llm/_spikes/v3_dogfood_spike.py
+++ b/hooks/lib/llm/_spikes/v3_dogfood_spike.py
@@ -166,7 +166,7 @@ async def run_v3_chain(diff: str, scope: str, dry_run: bool):
         print(f"  ✗ code-reviewer failed: {work_error}")
         print(f"  → elapsed={work_elapsed:.1f}s (before failure)")
         if "max_turns" in str(e):
-            print(f"  → hint: diff may be too large for max_turns=5; try --base <closer-sha> to narrow scope")
+            print("  → hint: diff may be too large for max_turns=5; try --base <closer-sha> to narrow scope")
 
     return handoff, report, sup_elapsed, work_elapsed, sup_error, work_error
 

--- a/hooks/lib/llm/_spikes/v3_prompt_loader_smoke.py
+++ b/hooks/lib/llm/_spikes/v3_prompt_loader_smoke.py
@@ -65,8 +65,8 @@ def main() -> int:
         match = text == on_disk
         print(f"  {name}: {len(text)} bytes, matches disk={match}")
         if not match:
-            print(f"    (Langfuse has different content than disk — likely a "
-                  f"newer version was promoted in the UI; not a failure.)")
+            print("    (Langfuse has different content than disk — likely a "
+                  "newer version was promoted in the UI; not a failure.)")
 
     print("\nStep 3/3: forcing file fallback (clearing LANGFUSE_PUBLIC_KEY) ...")
     saved = os.environ.pop("LANGFUSE_PUBLIC_KEY")

--- a/hooks/lib/llm/_spikes/v3_qdrant_smoke.py
+++ b/hooks/lib/llm/_spikes/v3_qdrant_smoke.py
@@ -122,7 +122,6 @@ from hooks.lib.llm.retrieval import (  # noqa: E402 — must follow guards
     query_sessions,
     upsert_session,
 )
-from qdrant_client import QdrantClient  # noqa: E402
 
 
 FIXTURES = [

--- a/hooks/lib/llm/_spikes/v3_spike.py
+++ b/hooks/lib/llm/_spikes/v3_spike.py
@@ -185,7 +185,7 @@ async def main():
     print(f"  rationale: {handoff.rationale}")
     print(f"  elapsed:   {sup_elapsed:.2f}s")
     if handoff.target not in ("deep-review",):
-        print(f"  note:      spike will run review workers regardless of supervisor choice")
+        print("  note:      spike will run review workers regardless of supervisor choice")
     print()
 
     # Phase 2: parallel workers
@@ -224,7 +224,7 @@ async def main():
     print(f"  {raw_count} raw finding(s) → {len(unified.findings)} unified after agent aggregation")
     print(f"  elapsed: {agg_elapsed:.2f}s")
     print()
-    print(f"  Narrative summary (from aggregator):")
+    print("  Narrative summary (from aggregator):")
     print(f"    {unified.summary}")
     print()
 
@@ -252,10 +252,10 @@ async def main():
     print(f"  Dedup:        {raw_count} raw → {len(unified.findings)} unified (saved {dedup_savings} duplicate{'s' if dedup_savings != 1 else ''})")
     print()
     print("Architecture validated:")
-    print(f"  ✓ Supervisor → HandoffResult (typed)")
-    print(f"  ✓ Workers in parallel → ReviewReport (typed)")
-    print(f"  ✓ Aggregator agent → ReviewReport (typed; semantic dedup + narrative)")
-    print(f"  ✓ End-to-end flow under Max auth, no API key required")
+    print("  ✓ Supervisor → HandoffResult (typed)")
+    print("  ✓ Workers in parallel → ReviewReport (typed)")
+    print("  ✓ Aggregator agent → ReviewReport (typed; semantic dedup + narrative)")
+    print("  ✓ End-to-end flow under Max auth, no API key required")
 
 
 if __name__ == "__main__":

--- a/hooks/lib/session.py
+++ b/hooks/lib/session.py
@@ -119,9 +119,9 @@ def get_session_id() -> str:
     sessions = registry.get("sessions", {})
     if not sessions:
         raise SessionNotFoundError(
-            f"❌ No active Claude Code sessions in registry!\n\n"
-            f"💡 Registry exists but contains no sessions\n"
-            f"💡 Try running a command in Claude Code first to populate the registry"
+            "❌ No active Claude Code sessions in registry!\n\n"
+            "💡 Registry exists but contains no sessions\n"
+            "💡 Try running a command in Claude Code first to populate the registry"
         )
 
     # Get current project directory

--- a/hooks/requirements-cli.py
+++ b/hooks/requirements-cli.py
@@ -28,7 +28,7 @@ from requirements import BranchRequirements
 from config import RequirementsConfig, load_yaml
 from git_utils import get_current_branch, is_git_repo, resolve_project_root
 from session import get_session_id, get_active_sessions, cleanup_stale_sessions, SessionNotFoundError
-from session_metrics import list_session_metrics, load_metrics
+from session_metrics import list_session_metrics
 from learning_updates import get_recent_updates, get_learning_stats, mark_rolled_back, get_update_by_id
 from state_storage import list_all_states
 from colors import success, error, warning, info, header, hint, dim, bold
@@ -2469,7 +2469,7 @@ def _cmd_upgrade_scan(args) -> int:
 
     result = registry.update_and_scan(scan_paths)
 
-    out(success(f"✅ Scan complete"))
+    out(success("✅ Scan complete"))
     out()
     out(f"   New projects:     {result['new']}")
     out(f"   Updated:          {result['updated']}")
@@ -2488,13 +2488,6 @@ def _cmd_upgrade_scan(args) -> int:
 
 def _cmd_upgrade_status(args) -> int:
     """Show feature status for a project or all projects."""
-    from feature_catalog import (
-        get_all_features,
-        detect_configured_features,
-        CATEGORY_REQUIREMENTS,
-        CATEGORY_HOOKS,
-        CATEGORY_GUARDS,
-    )
     from project_registry import ProjectRegistry
 
     registry = ProjectRegistry()
@@ -2564,10 +2557,10 @@ def _show_project_status(project_path: str, brief: bool = False) -> int:
         CATEGORY_HOOKS: [],
     }
 
-    for name, info in features.items():
-        cat = info.get('category', CATEGORY_REQUIREMENTS)
+    for name, feature_info in features.items():
+        cat = feature_info.get('category', CATEGORY_REQUIREMENTS)
         status = configured.get(name, False)
-        categories[cat].append((name, info, status))
+        categories[cat].append((name, feature_info, status))
 
     if brief:
         # One-line summary
@@ -2600,18 +2593,17 @@ def _show_project_status(project_path: str, brief: bool = False) -> int:
         out()
         out(bold(f"  {cat_label}:"))
 
-        for name, info, enabled in sorted(items, key=lambda x: x[0]):
+        for name, feature_info, enabled in sorted(items, key=lambda x: x[0]):
             if enabled:
                 status_str = success("✓ Enabled")
             else:
                 status_str = dim("○ Not configured")
                 missing_count += 1
 
-            introduced = info.get('introduced', '1.0')
             name_display = f"{name:<25}"
             out(f"    {name_display} {status_str}")
             if not enabled and not brief:
-                out(dim(f"      └─ {info.get('description', '')}"))
+                out(dim(f"      └─ {feature_info.get('description', '')}"))
 
     out()
     out(dim("─" * 60))
@@ -2631,7 +2623,6 @@ def _cmd_upgrade_recommend(args) -> int:
     """Generate YAML recommendations for missing features."""
     from feature_catalog import (
         get_all_features,
-        detect_configured_features,
         get_missing_features,
         get_feature_yaml,
         get_feature_info,

--- a/hooks/test_branch_size_calculator.py
+++ b/hooks/test_branch_size_calculator.py
@@ -9,10 +9,8 @@ Run with: python3 test_branch_size_calculator.py
 """
 
 import sys
-import os
 import subprocess
 import tempfile
-import time
 from pathlib import Path
 
 # Add lib directory to path
@@ -47,7 +45,7 @@ class TestRunner:
         print(f"Results: {self.passed}/{total} passed")
 
         if self.failed_tests:
-            print(f"\nFailed tests:")
+            print("\nFailed tests:")
             for name, msg in self.failed_tests:
                 print(f"  • {name}: {msg}")
 

--- a/hooks/test_diff_scope.py
+++ b/hooks/test_diff_scope.py
@@ -8,7 +8,6 @@ Uses real git repos in tempdirs — no subprocess mocking except for `gh` CLI.
 Run with: python3 hooks/test_diff_scope.py
 """
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -20,13 +19,9 @@ sys.path.insert(0, str(lib_path))
 
 from diff_scope import (
     DEFAULT_BASE,
-    DEFAULT_DIFF_FILE,
-    DEFAULT_SCOPE_FILE,
     DiffScopeError,
-    Scope,
     ensure_scope,
     prepare_diff_scope,
-    read_scope,
 )
 
 

--- a/hooks/test_requirements.py
+++ b/hooks/test_requirements.py
@@ -475,7 +475,7 @@ def test_git_root_resolution(runner: TestRunner):
 def test_git_worktree_support(runner: TestRunner):
     """Test that state is shared across git worktrees."""
     print("\n📦 Testing git worktree support...")
-    from git_utils import get_git_common_dir, is_git_repo
+    from git_utils import get_git_common_dir
     from state_storage import get_state_dir
     from requirements import BranchRequirements
 
@@ -7478,11 +7478,11 @@ def test_session_start_format_tiers(runner: TestRunner):
         # Test standard format
         standard = session_start_module.format_standard_status(reqs, config, "test-session", "feature/test-formats")
         runner.test("Standard format has table header", "| Requirement |" in standard,
-                   f"Missing table header")
+                   "Missing table header")
         runner.test("Standard format has Quick Start section", "Quick Start" in standard,
-                   f"Missing Quick Start section")
+                   "Missing Quick Start section")
         runner.test("Standard format shows triggers", "Edit" in standard or "git commit" in standard,
-                   f"Missing triggers")
+                   "Missing triggers")
         runner.test("Standard shows gating directive when unsatisfied",
                    "do NOT attempt Edit/Write/MultiEdit first" in standard,
                    f"Got: {standard[:600]}")
@@ -7500,7 +7500,7 @@ def test_session_start_format_tiers(runner: TestRunner):
         )
         runner.test("briefing_format=compact returns compact regardless of source",
                    "Requirements:" in adaptive_compact and "Session Briefing" not in adaptive_compact,
-                   f"Expected compact format")
+                   "Expected compact format")
 
         config_standard = dict(config_content)
         config_standard["hooks"] = {"session_start": {"briefing_format": "standard"}}
@@ -7512,7 +7512,7 @@ def test_session_start_format_tiers(runner: TestRunner):
         )
         runner.test("briefing_format=standard returns standard regardless of source",
                    "| Requirement |" in adaptive_standard and "Session Briefing" not in adaptive_standard,
-                   f"Expected standard format")
+                   "Expected standard format")
 
     # Test empty requirements config
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -9848,7 +9848,7 @@ def test_process_skill_auto_satisfy_mappings(runner: TestRunner):
     # Test: Deprecated /plan-review mapping removed in plugin v4.0.0
     runner.test("plan-review mapping removed in 4.0.0",
                'requirements-framework:plan-review' not in mappings,
-               f"DEFAULT_SKILL_MAPPINGS should not contain 'requirements-framework:plan-review'")
+               "DEFAULT_SKILL_MAPPINGS should not contain 'requirements-framework:plan-review'")
 
     # Test: Deprecated /quality-check mapping removed in plugin v4.0.0
     runner.test("quality-check not in mappings (deleted in v4.0)",
@@ -9858,8 +9858,6 @@ def test_process_skill_auto_satisfy_mappings(runner: TestRunner):
 def test_new_requirement_definitions(runner: TestRunner):
     """Test that new requirement definitions in example config are valid."""
     print("\n🎯 Testing new requirement definitions...")
-
-    from config import RequirementsConfig
 
     # Read the example config to check new requirement definitions exist
     # Try relative to test file first (portable), then hardcoded repo fallback
@@ -11346,7 +11344,7 @@ def test_obsidian_client(runner: TestRunner):
 def test_obsidian_session_logger(runner: TestRunner):
     """Test ObsidianSessionLogger lifecycle orchestrator."""
     print("\n📦 Testing Obsidian session logger...")
-    from unittest.mock import patch, MagicMock, call
+    from unittest.mock import patch, MagicMock
     from obsidian import ObsidianSessionLogger
 
     # Helper: create a mock config
@@ -11410,7 +11408,7 @@ def test_obsidian_session_logger(runner: TestRunner):
     logger_obj = ObsidianSessionLogger(config)
     with patch.object(logger_obj.client, 'create_note', return_value=True) as mock_create, \
          patch.object(logger_obj.client, 'set_properties', return_value=True) as mock_props, \
-         patch.object(logger_obj.client, 'read', return_value=None) as mock_read, \
+         patch.object(logger_obj.client, 'read', return_value=None), \
          patch.object(logger_obj.client, 'prepend', return_value=True) as mock_prepend:
         logger_obj.on_session_start("abc123", "/tmp/project", "feat/auth")
         runner.test("on_session_start calls create_note",
@@ -11544,7 +11542,7 @@ def test_obsidian_session_logger(runner: TestRunner):
     # Test 14: _ensure_index_note creates Dataview note when missing
     config = make_config(enabled=True)
     logger_obj = ObsidianSessionLogger(config)
-    with patch.object(logger_obj.client, 'read', return_value=None) as mock_read, \
+    with patch.object(logger_obj.client, 'read', return_value=None), \
          patch.object(logger_obj.client, 'create_note', return_value=True) as mock_create:
         logger_obj._ensure_index_note()
         runner.test("_ensure_index_note creates when missing",

--- a/plugins/requirements-framework/.claude-plugin/plugin.json
+++ b/plugins/requirements-framework/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "requirements-framework",
-  "version": "4.15.4",
+  "version": "4.15.5",
   "description": "Claude Code Requirements Framework - Complete development lifecycle from ideation to completion. Enforces workflow requirements through hooks, guides process with 21 development skills (brainstorming, TDD, debugging, verification), and provides comprehensive code review agents.",
   "author": {
     "name": "Harm"

--- a/plugins/requirements-framework/hooks/lib/blocking_strategy.py
+++ b/plugins/requirements-framework/hooks/lib/blocking_strategy.py
@@ -10,7 +10,7 @@ These requirements must be manually satisfied via the CLI using
 Examples: commit_plan, adr_reviewed, github_ticket
 """
 
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 # Import from sibling modules
 try:
@@ -22,9 +22,6 @@ except ImportError as e:
     # For testing, allow imports to fail gracefully but log warning
     import sys
     sys.stderr.write(f"[WARNING] blocking_strategy import failed: {e}\n")
-
-if TYPE_CHECKING:
-    from messages import MessageLoader
 
 
 class BlockingRequirementStrategy(RequirementStrategy):

--- a/plugins/requirements-framework/hooks/lib/feature_selector.py
+++ b/plugins/requirements-framework/hooks/lib/feature_selector.py
@@ -12,7 +12,6 @@ Usage:
     config = selector.build_config_from_features(selected, context='project')
 """
 from typing import Dict, List, Any
-from pathlib import Path
 
 
 # Feature catalog - maps requirement keys to user-friendly descriptions

--- a/plugins/requirements-framework/hooks/lib/guard_strategy.py
+++ b/plugins/requirements-framework/hooks/lib/guard_strategy.py
@@ -13,7 +13,7 @@ Guards are different from blocking/dynamic requirements:
 Examples: protected_branch (prevents edits on main/master)
 """
 
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 # Import from sibling modules
 try:
@@ -25,9 +25,6 @@ except ImportError as e:
     # For testing, allow imports to fail gracefully but log warning
     import sys
     sys.stderr.write(f"[WARNING] guard_strategy import failed: {e}\n")
-
-if TYPE_CHECKING:
-    from messages import MessageLoader
 
 
 class GuardRequirementStrategy(RequirementStrategy):

--- a/plugins/requirements-framework/hooks/lib/session.py
+++ b/plugins/requirements-framework/hooks/lib/session.py
@@ -119,9 +119,9 @@ def get_session_id() -> str:
     sessions = registry.get("sessions", {})
     if not sessions:
         raise SessionNotFoundError(
-            f"❌ No active Claude Code sessions in registry!\n\n"
-            f"💡 Registry exists but contains no sessions\n"
-            f"💡 Try running a command in Claude Code first to populate the registry"
+            "❌ No active Claude Code sessions in registry!\n\n"
+            "💡 Registry exists but contains no sessions\n"
+            "💡 Try running a command in Claude Code first to populate the registry"
         )
 
     # Get current project directory

--- a/plugins/requirements-framework/hooks/requirements-cli.py
+++ b/plugins/requirements-framework/hooks/requirements-cli.py
@@ -28,7 +28,7 @@ from requirements import BranchRequirements
 from config import RequirementsConfig, load_yaml
 from git_utils import get_current_branch, is_git_repo, resolve_project_root
 from session import get_session_id, get_active_sessions, cleanup_stale_sessions, SessionNotFoundError
-from session_metrics import list_session_metrics, load_metrics
+from session_metrics import list_session_metrics
 from learning_updates import get_recent_updates, get_learning_stats, mark_rolled_back, get_update_by_id
 from state_storage import list_all_states
 from colors import success, error, warning, info, header, hint, dim, bold
@@ -2469,7 +2469,7 @@ def _cmd_upgrade_scan(args) -> int:
 
     result = registry.update_and_scan(scan_paths)
 
-    out(success(f"✅ Scan complete"))
+    out(success("✅ Scan complete"))
     out()
     out(f"   New projects:     {result['new']}")
     out(f"   Updated:          {result['updated']}")
@@ -2488,13 +2488,6 @@ def _cmd_upgrade_scan(args) -> int:
 
 def _cmd_upgrade_status(args) -> int:
     """Show feature status for a project or all projects."""
-    from feature_catalog import (
-        get_all_features,
-        detect_configured_features,
-        CATEGORY_REQUIREMENTS,
-        CATEGORY_HOOKS,
-        CATEGORY_GUARDS,
-    )
     from project_registry import ProjectRegistry
 
     registry = ProjectRegistry()
@@ -2564,10 +2557,10 @@ def _show_project_status(project_path: str, brief: bool = False) -> int:
         CATEGORY_HOOKS: [],
     }
 
-    for name, info in features.items():
-        cat = info.get('category', CATEGORY_REQUIREMENTS)
+    for name, feature_info in features.items():
+        cat = feature_info.get('category', CATEGORY_REQUIREMENTS)
         status = configured.get(name, False)
-        categories[cat].append((name, info, status))
+        categories[cat].append((name, feature_info, status))
 
     if brief:
         # One-line summary
@@ -2600,18 +2593,17 @@ def _show_project_status(project_path: str, brief: bool = False) -> int:
         out()
         out(bold(f"  {cat_label}:"))
 
-        for name, info, enabled in sorted(items, key=lambda x: x[0]):
+        for name, feature_info, enabled in sorted(items, key=lambda x: x[0]):
             if enabled:
                 status_str = success("✓ Enabled")
             else:
                 status_str = dim("○ Not configured")
                 missing_count += 1
 
-            introduced = info.get('introduced', '1.0')
             name_display = f"{name:<25}"
             out(f"    {name_display} {status_str}")
             if not enabled and not brief:
-                out(dim(f"      └─ {info.get('description', '')}"))
+                out(dim(f"      └─ {feature_info.get('description', '')}"))
 
     out()
     out(dim("─" * 60))
@@ -2631,7 +2623,6 @@ def _cmd_upgrade_recommend(args) -> int:
     """Generate YAML recommendations for missing features."""
     from feature_catalog import (
         get_all_features,
-        detect_configured_features,
         get_missing_features,
         get_feature_yaml,
         get_feature_info,

--- a/plugins/requirements-framework/skills/requirements-framework-builder/examples/custom-requirement-strategy.py
+++ b/plugins/requirements-framework/skills/requirements-framework-builder/examples/custom-requirement-strategy.py
@@ -10,7 +10,7 @@ To add this strategy:
 3. Configure in requirements.yaml
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 from base_strategy import BaseStrategy
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,6 +2,13 @@
 line-length = 100
 target-version = "py39"
 
+# The plugin bundle under plugins/requirements-framework/hooks/ is a GENERATED,
+# byte-identical mirror of hooks/*.py + hooks/lib/ (scripts/build_plugin_hooks.py,
+# enforced by its --check freshness test). Linting the source of truth covers it —
+# don't double-lint the generated copy, which would only re-flag the same deliberate
+# sys.path-then-import (E402) pattern already ignored for the source layer.
+extend-exclude = ["plugins/requirements-framework/hooks"]
+
 [lint]
 select = ["E", "F", "W"]  # Basic error, pyflakes, and warning rules
 ignore = ["E501"]  # Line length handled separately

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -9,7 +9,6 @@ real ledger at ~/.claude/requirements-framework/usage/.
 """
 
 import json
-import os
 import stat
 import sys
 import tempfile


### PR DESCRIPTION
## Root cause
CI ran **no ruff step**, so **158 lint violations** accumulated on `master` invisibly — the only ruff enforcement was the opt-in `/v3-review` tool gate, which is exactly how this surfaced. The lint gate existed at *review* time but never at *merge* time.

## Fix (correct, not blind `--fix`)
1. **Exclude the generated bundle from ruff** (`ruff.toml`) — `plugins/requirements-framework/hooks/` is a byte-identical mirror of already-linted source (`build --check` enforces equality). **94/158** were just the bundle re-flagging the deliberate `sys.path` E402 pattern.
2. **Fix the 48 real source violations per-case** — F541 (drop stray `f`), F401 (scope-accurate removal, **verified none was an intentional re-export**), F811/F841/F402 (understood individually; e.g. renamed a loop var shadowing `colors.info` rather than touching the import). Cleaned via a fix→adversarial-verify workflow + an independent re-export/runtime check.
3. **Add a pinned `ruff check` gate to CI** (`ruff==0.12.12`) — closes the hole so lint debt can't silently merge again.

## Verified
ruff **0** · main suite **1461/1461** · `tests/` **23/23** · build/render `--check` clean · all edited modules import at runtime. Plugin 4.15.4 → 4.15.5 (bundled source changed).
