### PR TITLE
fix: force-exclude generated bundle from ruff (unblock /v3-review gate)

### DIFF
--- a/.claude/re-enablement-ledger.md
+++ b/.claude/re-enablement-ledger.md
@@ -12,11 +12,37 @@ Legend: ✅ graduated · 🟡 in progress · ⬜ not started · ❌ dropped
 | R1 | Core gating (one requirement) | ✅ graduated | Works end-to-end; no false positives; state integrity holds |
 | R2 | Status injection + statusline | ⬜ | — |
 | R3 | Plugin review commands (/deep-review, /arch-review) | ✅ graduated | --plugin-dir session: hooks fired + gate blocked an edit, zero errors |
-| R4 | /v3-review LIVE (budget rung) | ⬜ | — |
-| R5 | Observability / Langfuse | ⬜ | — |
+| R4 | /v3-review LIVE (budget rung) | ✅ graduated | 2026-06-07 live run end-to-end (see below) |
+| R5 | Observability / Langfuse | 🟡 | traces exported live in the R4 run (session 861c5f9e); always-on validation pending |
 | R6 | Eval harness + golden set | ⬜ | — |
 | R7 | Retrieval / memory / Qdrant | ⬜ | — |
 | aux | Obsidian, session-learning | ⬜ | — |
+
+## R4 — /v3-review LIVE — ✅ GRADUATED (2026-06-07)
+
+**First live run of the re-enablement** (user-run, foreground, on the `force-exclude` branch),
+scope `HEAD~3..HEAD` (140 files — the ruff-cleanup merge):
+
+- **Ran end-to-end**: tool gate passed (after the `force-exclude` fix) → 10-worker fan-out →
+  aggregated ADR-013 report. **9/10 workers survived** (code-reviewer failed
+  `error_max_turns` on the wide scope — proceed-with-survivors by design, ADR-017/018).
+- **Verdict READY**: 0 CRITICAL / 0 IMPORTANT / 4 SUGGESTION — and the suggestions were
+  *genuinely useful*: all four targeted the brand-new `test_ruff_force_excludes_bundle`
+  regression guard (silent skip, swallowed stderr, excluded-vs-incidentally-clean ambiguity,
+  untested traversal branch). **All four were folded back into PR #97 before merge** —
+  the review→fix→merge loop worked on its own enabling change.
+- **Cost $6.84 / 11 calls** on a wide 140-file scope (consistent with the $2–12 model;
+  narrow scopes land $2–3). **Langfuse traces exported** (session `861c5f9e`, self-hosted
+  stack at :3000) — observability live, which also moves R5 to 🟡.
+- Known wrinkles (both pre-documented): the SDK `aclose(): asynchronous generator is
+  already running` teardown noise (upstream, non-fatal), and `error_max_turns` on the
+  widest worker — feeds Step 17b (per-call caps) and Step 20 (sonnet pinning) data needs.
+
+**Graduation gate met**: runs live under Max auth, produces actionable findings, survives a
+worker failure gracefully, exports traces, cost within model. Two aborted-gate runs before
+this one cost $0.00 (the deterministic gate doing its job).
+
+---
 
 ### R1 enhancement — evidence-gated commit_plan (`step-2-evidence-gated-commit-plan`, plugin 4.9.0)
 

--- a/hooks/test_requirements.py
+++ b/hooks/test_requirements.py
@@ -34,6 +34,7 @@ class TestRunner:
     def __init__(self):
         self.passed = 0
         self.failed = 0
+        self.skipped = 0
         self.errors = []
 
     def test(self, name: str, condition: bool, msg: str = ""):
@@ -46,12 +47,23 @@ class TestRunner:
             self.failed += 1
             self.errors.append(f"{name}: {msg}")
 
+    def skip(self, name: str, reason: str = ""):
+        """Record an explicitly-skipped check so it is visible in the summary.
+
+        A skipped guard must be distinguishable from a passed guard — silent
+        early-returns make the totals lie (flagged by /v3-review on the ruff
+        force-exclude regression guard).
+        """
+        print(f"  ⊘ SKIP {name}: {reason}")
+        self.skipped += 1
+
     def summary(self) -> int:
         """Print summary and return exit code."""
         total = self.passed + self.failed
         print()
         print(f"{'='*50}")
-        print(f"Results: {self.passed}/{total} tests passed")
+        skipped_note = f" ({self.skipped} skipped)" if self.skipped else ""
+        print(f"Results: {self.passed}/{total} tests passed{skipped_note}")
         if self.errors:
             print("\nFailures:")
             for err in self.errors:
@@ -10006,6 +10018,65 @@ def test_plugin_hooks_bundle_fresh(runner: TestRunner):
                 pass
 
 
+def test_ruff_force_excludes_bundle(runner: TestRunner):
+    """The generated plugin bundle is force-excluded from ruff for EXPLICIT paths.
+
+    ruff's `extend-exclude` only skips the bundle during directory traversal
+    (`ruff check .`). The /v3-review tool gate runs `ruff check -- <changed files>`
+    (explicit paths), so without `force-exclude = true` it would lint the generated
+    bundle and abort on its deliberate sys.path E402 pattern. This guards that
+    regression (it bit a real `/v3-review` run twice).
+    """
+    import shutil
+    print("\n🧹 Testing ruff force-excludes the generated bundle (explicit paths)...")
+    if not shutil.which("ruff"):
+        # Visible skip, not a silent return — CI always has ruff (pinned in
+        # ci.yml), so this only fires on a dev box without it.
+        runner.skip("ruff force-exclude bundle guard", "ruff not installed")
+        return
+    repo_root = Path(__file__).resolve().parent.parent
+    bundle_file = "plugins/requirements-framework/hooks/requirements-cli.py"
+    if not (repo_root / bundle_file).exists():
+        runner.test("bundle file present for force-exclude check", False, bundle_file)
+        return
+
+    def _ruff(*args: str):
+        r = subprocess.run(
+            ["ruff", "check", *args],
+            cwd=str(repo_root), capture_output=True, text=True,
+        )
+        detail = (f"exit={r.returncode}\nstdout:\n{r.stdout[:2000]}"
+                  f"\nstderr:\n{r.stderr[:2000]}")
+        return r.returncode, detail
+
+    # Step 1 — prove the bundle file WOULD flag without the project config
+    # (--isolated ignores ruff.toml). Without this, exit-0 in step 2 could just
+    # mean the bundle happened to be lint-clean, not that the exclude works.
+    rc_isolated, detail_isolated = _ruff("--isolated", "--", bundle_file)
+    runner.test(
+        "bundle file flags under --isolated (content genuinely lintable)",
+        rc_isolated != 0, detail_isolated,
+    )
+
+    # Step 2 — with the project config, the SAME explicit path is skipped
+    # (force-exclude honored — this is the /v3-review tool-gate invocation).
+    rc_configured, detail_configured = _ruff("--", bundle_file)
+    runner.test(
+        "ruff check -- <generated bundle file> is clean (force-exclude honored)",
+        rc_configured == 0, detail_configured,
+    )
+
+    # Step 3 — the DIRECTORY-TRAVERSAL branch CI relies on (`ruff check .` +
+    # extend-exclude). Scoped to E402: the bundle's 94 deliberate sys.path
+    # violations would flag if extend-exclude were removed, while source stays
+    # clean via the per-file-ignores.
+    rc_traversal, detail_traversal = _ruff(".", "--select", "E402")
+    runner.test(
+        "ruff check . --select E402 is clean (extend-exclude traversal honored)",
+        rc_traversal == 0, detail_traversal,
+    )
+
+
 def test_plugin_hooks_json_self_contained(runner: TestRunner):
     """hooks.json is plugin-root-relative, not deploy-path-bound.
 
@@ -12874,6 +12945,7 @@ def main():
     test_new_requirement_definitions(runner)
     test_process_skill_message_files(runner)
     test_plugin_hooks_bundle_fresh(runner)
+    test_ruff_force_excludes_bundle(runner)
     test_plugin_hooks_json_self_contained(runner)
     test_plugin_skill_files_exist(runner)
     test_plugin_command_files_exist(runner)

--- a/ruff.toml
+++ b/ruff.toml
@@ -9,6 +9,12 @@ target-version = "py39"
 # sys.path-then-import (E402) pattern already ignored for the source layer.
 extend-exclude = ["plugins/requirements-framework/hooks"]
 
+# Honor the exclude even when files are passed to ruff EXPLICITLY (not just via
+# directory traversal). Without this, `extend-exclude` only applies to `ruff check .`
+# — the /v3-review tool gate runs `ruff check -- <changed files>`, so it would still
+# lint the generated bundle and abort on its deliberate sys.path E402 pattern.
+force-exclude = true
+
 [lint]
 select = ["E", "F", "W"]  # Basic error, pyflakes, and warning rules
 ignore = ["E501"]  # Line length handled separately


### PR DESCRIPTION
The ruff `extend-exclude` only applied to `ruff check .` (CI). The /v3-review gate runs `ruff check -- <files>` (explicit paths), which ruff lints even when excluded — so it kept aborting on the generated bundle's deliberate sys.path E402 pattern (hit a real run twice). Fix: `force-exclude = true` honors the exclusion for explicit paths too. Source still fully linted; only the generated mirror is skipped. Regression test added. 1462/1462, CI ruff path unchanged.