### PR TITLE
chore: mark generated plugin artifacts as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Mark machine-generated artifacts as linguist-generated.
+#
+# These are byte-identical, tool-produced mirrors of authored source — they are
+# committed (so the plugin is self-contained / ships rendered), but reviewing or
+# diff-highlighting them is noise: any real change lives in the source twin.
+#
+#   * The plugin hook BUNDLE — scripts/build_plugin_hooks.py mirrors hooks/*.py +
+#     hooks/lib/** into plugins/requirements-framework/hooks/ (its --check test
+#     enforces byte-for-byte equality with the source).
+#   * Rendered plugin prompts — scripts/render_prompts.py renders *.md.j2 -> *.md
+#     for agents / commands / skills (its --check test enforces freshness).
+#
+# Effect: GitHub collapses them in PR diffs and drops them from language stats,
+# and generated-aware review tools (Graphite, and a future /v3-review scope
+# filter) skip them. Querying: `git check-attr linguist-generated -- <file>`.
+#
+# NOT marked (intentionally authored): hooks.json (the hook-registration source
+# of truth), the *.md.j2 sources themselves, and skills/*/references/*.md.
+
+plugins/requirements-framework/hooks/**/*.py       linguist-generated=true
+plugins/requirements-framework/agents/*.md         linguist-generated=true
+plugins/requirements-framework/commands/*.md       linguist-generated=true
+plugins/requirements-framework/skills/*/SKILL.md   linguist-generated=true


### PR DESCRIPTION
Marks the committed-but-generated plugin trees (the hook bundle `plugins/.../hooks/**/*.py` + rendered `agents/commands/skills/*.md` from their `.md.j2` sources) as `linguist-generated`. GitHub collapses them in PR diffs + drops them from language stats; generated-aware tools (Graphite, a future /v3-review scope filter) skip them. Authored files (hooks.json, `.md.j2` sources, `references/*.md`) left unmarked — verified via `git check-attr`. Repo metadata only; no code/version change. (This is the cheap, this-repo half of the 'exclude generated from review' idea; the general tool feature stays parked in Task #4.)